### PR TITLE
Update service ExecStart to use uv venv Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ apt install git curl python3.11 libcairo2
    systemctl enable discord-blue
    systemctl start discord-blue
    ```
+   The service now runs using `/opt/discord-blue/.venv/bin/python` to match the
+   Python version created by `uv venv`.
 
 **Note**: Make sure to run once to create the config file and input your discord token along with server and bot channel.
 

--- a/discord-blue.service
+++ b/discord-blue.service
@@ -5,7 +5,8 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/root/.local/bin/poetry run discord-blue
+# Use the same Python version installed with uv venv
+ExecStart=/opt/discord-blue/.venv/bin/python -m discord_blue
 User=root
 Group=root
 Type=idle


### PR DESCRIPTION
## Summary
- run service with venv Python interpreter
- clarify README systemd instructions

## Testing
- `python3 -m compileall -q discord_blue`
