### PR TITLE
Add Python 3.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Debian-based LXC.
 
 ## Prerequisites
 
-Ensure you have `git`, `curl`, `libcairo2`, and `python3` installed.
+Ensure you have `git`, `curl`, `libcairo2`, and `python3.12` installed.
 
 ```
 apt update
-apt install git curl python3.11 libcairo2
+apt install git curl python3.12 libcairo2
 ```
 
 ## Installation Steps
@@ -21,7 +21,7 @@ apt install git curl python3.11 libcairo2
 
 2. Install Python Poetry:
    ```
-   curl -sSL https://install.python-poetry.org | python3.11 -
+   curl -sSL https://install.python-poetry.org | python3.12 -
    ```
 
 3. Clone the Discord Blue Repository:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+requires-python = ">=3.12"
 
 [tool.poetry]
 name = "discord-blue"
@@ -10,7 +14,7 @@ authors = ["Chris Busillo <info@shinycomputers.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 toml = "^0.10.2"
 discord = "^2.3.2"
 printnodeapi = "^0.2.0"
@@ -29,6 +33,6 @@ discord-blue = 'discord_blue.__main__:main'
 
 [tool.mypy]
 strict = true
-python_version = 3.11
+python_version = 3.12
 warn_any_return = false
 warn_no_untyped_call = false


### PR DESCRIPTION
## Summary
- bump Python runtime to 3.12
- document Python 3.12 requirement in README

## Testing
- `uv pip install -e .` *(fails: No route to host)*
- `pytest -q`