### PR TITLE
Add Dockerfile for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/astral-sh/uv:debian
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcairo2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies declared in pyproject.toml
+COPY pyproject.toml ./
+RUN uv pip install --system -r pyproject.toml
+
+# Copy the rest of the project and install in editable mode
+COPY . ./
+RUN uv pip install --system -e .
+
+# Use uv to run the bot
+ENTRYPOINT ["uv", "run", "python", "-m", "discord_blue"]
+

--- a/README.md
+++ b/README.md
@@ -49,3 +49,23 @@ apt install git curl python3.11 libcairo2
 ```
 /root/.local/bin/poetry run discord-blue
 ```
+
+## Docker
+
+A `Dockerfile` is provided to build a containerized version of the bot. It
+uses the [`ghcr.io/astral-sh/uv:debian`](https://github.com/astral-sh/uv) base
+image so `uv` is already available for dependency installation.
+
+Build the image:
+```bash
+docker build -t discord-blue .
+```
+
+Run the bot:
+```bash
+docker run --rm discord-blue
+```
+
+The container entrypoint uses `uv run` so any project dependencies are
+isolated and executed with the version pinned in `pyproject.toml`.
+


### PR DESCRIPTION
## Summary
- provide a Dockerfile for running the bot
- document how to build and run the container

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`
