### PR TITLE
Add uv-based setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
         run: |
           ssh ${{ vars.PRODUCTION_USER }}@${{ vars.PRODUCTION_SERVER }} "cd /opt/discord-blue; \
           export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring; \
-          git pull; \ 
-          poetry lock; \
-          poetry install; \
+          git pull; \
+          uv venv --upgrade --dev; \
           systemctl restart discord-blue"
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -95,12 +95,6 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/.idea/mypy.xml
+++ b/.idea/mypy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="MypyConfigService">
-    <option name="customMypyPath" value="$USER_HOME$/Library/Caches/pypoetry/virtualenvs/discord-blue-I9B2aOgX-py3.11/bin/mypy" />
+    <option name="customMypyPath" value=".venv/bin/mypy" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -19,24 +19,19 @@ apt install git curl python3.12 libcairo2
    apt update
    ```
 
-2. Install Python Poetry:
-   ```
-   curl -sSL https://install.python-poetry.org | python3.12 -
-   ```
-
-3. Clone the Discord Blue Repository:
+2. Clone the Discord Blue Repository:
    ```
    cd /opt
    git clone https://github.com/cbusillo/discord-blue
    cd discord-blue
    ```
 
-4. Install Dependencies using Poetry:
+3. Install Dependencies with uv:
    ```
-   /root/.local/bin/poetry install
+   uv venv --dev
    ```
 
-5. Setup and Start the Systemd Service:
+4. Setup and Start the Systemd Service:
    ```
    cp discord-blue.service /etc/systemd/system/
    systemctl daemon-reload
@@ -49,7 +44,7 @@ apt install git curl python3.12 libcairo2
 **Note**: Make sure to run once to create the config file and input your discord token along with server and bot channel.
 
 ```
-/root/.local/bin/poetry run discord-blue
+uv run python -m discord_blue
 ```
 
 ## Docker
@@ -70,4 +65,17 @@ docker run --rm discord-blue
 
 The container entrypoint uses `uv run` so any project dependencies are
 isolated and executed with the version pinned in `pyproject.toml`.
+
+## Codex Setup
+
+If you are working in the Codex environment, run the helper script to install
+`uv` and all required dependencies before network access is removed:
+
+```bash
+./setup_codex.sh
+```
+
+The script creates a `.venv` with `uv` and installs all project and
+development dependencies declared in `pyproject.toml` (the `dev` group) for
+local testing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,35 +1,34 @@
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-
-requires-python = ">=3.12"
-
-[tool.poetry]
+[project]
 name = "discord-blue"
 version = "0.1.0"
 description = ""
-authors = ["Chris Busillo <info@shinycomputers.com>"]
+authors = [{ name = "Chris Busillo", email = "info@shinycomputers.com" }]
 readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "toml>=0.10.2",
+    "nextcord>=2.5.1",
+    "printnodeapi>=0.2.0",
+    "pynacl>=1.5.0",
+    "modern-shippo==3.0.1",
+    "reportlab>=4.0.6",
+    "svglib>=1.5.1",
+]
 
-[tool.poetry.dependencies]
-python = "^3.12"
-toml = "^0.10.2"
-nextcord = "^2.5.1"
-printnodeapi = "^0.2.0"
-pynacl = "^1.5.0"
-modern-shippo = "3.0.1"
-reportlab = "^4.0.6"
-svglib = "^1.5.1"
+[project.optional-dependencies]
+dev = [
+    "setuptools>=68.2.2",
+    "black>=23.9.1",
+    "types-toml>=0.10.8.7",
+]
 
-[tool.poetry.group.dev.dependencies]
-setuptools = "^68.2.2"
-black = "^23.9.1"
-types-toml = "^0.10.8.7"
-
-[tool.poetry.scripts]
-discord-blue = 'discord_blue.__main__:main'
+[project.scripts]
+discord-blue = "discord_blue.__main__:main"
 
 [tool.mypy]
 strict = true

--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install system dependencies
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    libcairo2 \
+    python3.12 \
+    python3.12-venv \
+    python3.12-dev \
+    build-essential
+
+# Install uv package manager
+curl -Ls https://astral.sh/uv/install.sh | bash
+
+# Ensure uv is available on PATH
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+# Create a virtual environment and install project and development dependencies
+uv venv --dev
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- remove Poetry metadata and convert `pyproject.toml` to PEP 621 for uv
- update Codex setup script to rely on `uv venv --dev`
- document uv usage instead of Poetry in the README
- adjust GitHub workflow to use uv
- clean up old Poetry references

## Testing
- `uv pip install -e . --system` *(fails: No route to host)*
- `black --line-length 133 discord_blue`
- `mypy discord_blue` *(fails: missing stubs and other errors)*
