### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cbusillo/discord-blue/security/code-scanning/3](https://github.com/cbusillo/discord-blue/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best minimal fix without changing behavior: set workflow-level permissions to read-only for repository contents (`contents: read`). This is sufficient for typical checkout/read operations and does not grant unnecessary write scopes. Since this workflow does not show any step requiring token write access, this is the safest baseline.

Change needed in `.github/workflows/main.yml`:
- Insert a root-level `permissions:` block between `on:` triggers and `jobs:`.
- No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
