### PR TITLE
Clean up GitHub workflow config

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -1,6 +1,6 @@
 {
   "defaultBranch": "main",
-  "importantWorkflows": ["Deploy to Production", "CodeQL"],
+  "importantWorkflows": ["Deploy to Production"],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],


### PR DESCRIPTION
## Summary
- Remove stale `CodeQL` from the GitHub repo workflow config.

## Verification
- Parsed by local JSON validation during edit.
- Branch protection state verified separately for active repos.
