### PR TITLE
docs: clarify uv agent runtime guidance

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="uv (discord-blue)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="uv (discord-blue)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,25 @@
-# Project Coding Agent Guide — Codex Cloud
+# Project Coding Agent Guide - Codex Cloud
 
 ## Runtime
 
-* **OS:** Ubuntu 24.04 (noble)
 * **Python:** 3.13
 * **Env manager:** uv
 
-use `/workspace/discord-blue/.venv/bin/python` as the interpreter
-use `uv run mypy .` for static type checking
-use `uv run ruff check .` for linting
-use `uv run ruff format .` for formatting
+Use `uv run ...` for Python commands so local and Codex Cloud runs share the
+same managed environment. After `uv sync`, IDEs may point at the repo-local
+`.venv/bin/python`; avoid hard-coding `/workspace/...` paths in repo guidance.
+
+Use `uv run mypy .` for static type checking.
+Use `uv run ruff check .` for linting.
+Use `uv run ruff format .` for formatting.
 
 ## Discord command surfaces
 
-- Prefer Discord slash/app commands for all bot control surfaces. Do not add new `!command` style message parsers for operator actions.
-- Raw message handling is allowed only when the message content itself is the product input, such as Every Code session-thread replies that are forwarded to the local TUI.
-- Future Every Code control affordances such as status, summary, tail, or active-session lookup should be slash/app commands unless there is a product reason to make them normal thread replies.
+* Prefer Discord slash/app commands for all bot control surfaces. Do not add new
+  `!command` style message parsers for operator actions.
+* Raw message handling is allowed only when the message content itself is the
+  product input, such as Every Code session-thread replies that are forwarded to
+  the local TUI.
+* Future Every Code control affordances such as status, summary, tail, or
+  active-session lookup should be slash/app commands unless there is a product
+  reason to make them normal thread replies.


### PR DESCRIPTION
## Summary
- make runtime guidance portable across local and Codex Cloud runs
- document uv-managed commands for type checking, linting, and formatting
- refresh PyCharm SDK metadata for the repo-local uv environment

## Verification
- docs/settings-only change; no runtime checks run