### PR TITLE
feat(every-code): add Discord new session command

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -763,6 +763,38 @@ class EveryCodeBridge:
         await session.websocket.send_json(command.to_message())
         return "Asked Every Code to pause what it is doing now."
 
+    async def send_new_session(
+        self,
+        channel: object,
+        user: discord.User | discord.Member,
+    ) -> str:
+        if not isinstance(channel, discord.Thread):
+            return "Use `/code new` inside an Every Code session thread."
+        if not self.is_operator(user):
+            return "Only Every Code operators can start a new session."
+
+        session = self.sessions.get_by_thread(channel.id)
+        if session is None:
+            return "This thread is not attached to a live Every Code session."
+        if session.websocket.closed:
+            return "Every Code session is offline; new session was not started."
+
+        command = RemoteCommand(
+            command_id=str(uuid.uuid4()),
+            session_id=session.session_id,
+            session_epoch=session.session_epoch,
+            kind="new_session",
+            issued_by=str(user.id),
+        )
+        session.pending_commands[command.command_id] = PendingRemoteCommand(
+            thread_id=channel.id,
+            message_id=session.control_message_id,
+            kind="new_session",
+            reject_notice="Every Code could not start a new session",
+        )
+        await session.websocket.send_json(command.to_message())
+        return "Asked Every Code to start a new session in this folder."
+
     async def send_end_session(
         self,
         channel: object,

--- a/discord_blue/doodads/every_code/protocol.py
+++ b/discord_blue/doodads/every_code/protocol.py
@@ -174,6 +174,7 @@ class RemoteCommand:
         "reply",
         "continue_autonomously",
         "pause_current_turn",
+        "new_session",
         "end_session",
         "request_user_input_response",
         "status_request",

--- a/discord_blue/doodads/every_code_doodad.py
+++ b/discord_blue/doodads/every_code_doodad.py
@@ -121,6 +121,21 @@ class EveryCodeDoodad(commands.Cog):
         )
 
     @code_group.command(
+        name="new",
+        description="Ask this Every Code session to start a fresh chat in the same folder.",
+    )
+    async def new_session_command(self, interaction: discord.Interaction[BlueBot]) -> None:
+        if not self.bot.config.every_code.enabled:
+            await interaction.response.send_message("Every Code is not enabled.", ephemeral=True)
+            return
+
+        response = await self.bridge.send_new_session(
+            interaction.channel,
+            interaction.user,
+        )
+        await interaction.response.send_message(response, ephemeral=True)
+
+    @code_group.command(
         name="end-session",
         description="Ask this Every Code session to disconnect.",
     )

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -437,6 +437,33 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn(command_id, session.pending_commands)
 
+    async def test_new_session_routes_to_registered_session_websocket(self) -> None:
+        config = Config()
+        config.discord.employee_role_name = ""
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        websocket = FakeWebSocket()
+        session = EveryCodeSession(hello=make_hello(), websocket=websocket, thread_id=555)
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        response = await bridge.send_new_session(thread, SimpleNamespace(id=123))
+
+        self.assertEqual(response, "Asked Every Code to start a new session in this folder.")
+        self.assertEqual(len(websocket.sent_json), 1)
+        sent = websocket.sent_json[0]
+        self.assertEqual(sent["type"], "command")
+        self.assertEqual(sent["session_id"], "session-1")
+        self.assertEqual(sent["session_epoch"], "epoch-1")
+        self.assertEqual(sent["kind"], "new_session")
+        self.assertIsNone(sent["text"])
+        self.assertEqual(sent["issued_by"], "123")
+        pending = session.pending_commands[str(sent["command_id"])]
+        self.assertEqual(pending.thread_id, 555)
+        self.assertIsNone(pending.message_id)
+        self.assertEqual(pending.kind, "new_session")
+        self.assertEqual(pending.reject_notice, "Every Code could not start a new session")
+
     async def test_go_ahead_interaction_replies_ephemerally(self) -> None:
         config = Config()
         config.discord.employee_role_name = ""


### PR DESCRIPTION
## Summary
- add /code new for Every Code Discord session threads
- send a new_session remote command through the existing Every Code bridge
- cover the bridge command routing with a focused unit test

## Validation
- uv run python -m unittest discover -s tests
- uv run ruff check discord_blue/doodads/every_code/protocol.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code_doodad.py tests/test_every_code.py
- uv run ruff format --check discord_blue/doodads/every_code/protocol.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code_doodad.py tests/test_every_code.py
- uv run mypy discord_blue/doodads/every_code/protocol.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code_doodad.py tests/test_every_code.py