### PR TITLE
Quiet Every Code reply reactions

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -948,6 +948,9 @@ class EveryCodeBridge:
             if isinstance(channel, discord.Thread):
                 await self.refresh_session_controls(session, channel)
             return
+        if command.kind == "reply" and reaction != REACTION_REJECTED:
+            await self.clear_message_transient_reactions(command.thread_id, command.message_id)
+            return
         await self.set_message_reaction(command.thread_id, command.message_id, reaction)
 
     async def handle_approval_request(self, approval: RemoteApprovalRequest) -> None:
@@ -1498,6 +1501,23 @@ class EveryCodeBridge:
                         await message.remove_reaction(existing, bot_user)
         except discord.DiscordException:
             logger.warning("Unable to update Every Code reply reaction %s", message_id)
+
+    async def clear_message_transient_reactions(self, thread_id: int, message_id: int) -> None:
+        channel = self.bot.get_channel(thread_id)
+        if not isinstance(channel, discord.Thread):
+            return
+        bot_user = self.bot.user
+        if bot_user is None:
+            return
+        try:
+            message = await channel.fetch_message(message_id)
+        except discord.DiscordException:
+            logger.warning("Unable to fetch Every Code reply message %s", message_id)
+            return
+
+        for existing in TRANSIENT_REACTIONS:
+            with suppress(discord.DiscordException):
+                await message.remove_reaction(existing, bot_user)
 
     async def post_assistant_message(self, thread_id: int, text: str) -> None:
         for message in self.format_assistant_messages(text):

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -713,6 +713,41 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(session.control_interruptions_enabled)
         self.assertEqual(websocket.sent_json[0]["kind"], "reply")
 
+    async def test_thread_reply_ack_clears_delivery_receipt(self) -> None:
+        config = Config()
+        config.discord.employee_role_name = ""
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        websocket = FakeWebSocket()
+        control_message = add_bot_message(thread, 801, "\u200b")
+        control_message.reactions = ["▶️", bridge_module.REACTION_CONTROL_STATUS, "⏹️"]
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=websocket,
+            thread_id=555,
+            control_message_id=801,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+        reply_message = FakeReplyMessage(802, thread, "Run the quick path")
+        thread.add_message(reply_message)
+
+        await bridge.send_thread_reply(cast(Any, reply_message))
+        command_id = next(iter(session.pending_commands))
+
+        await bridge.handle_command_ack({"session_id": "session-1", "command_id": command_id})
+
+        self.assertEqual(reply_message.reactions, [])
+        self.assertEqual(session.active_command_id, command_id)
+        self.assertEqual(
+            control_message.reactions,
+            [
+                bridge_module.REACTION_QUEUED,
+                bridge_module.REACTION_CONTROL_PAUSE,
+                bridge_module.REACTION_CONTROL_END,
+            ],
+        )
+
     async def test_thread_reply_turn_complete_moves_controls_after_assistant(self) -> None:
         config = Config()
         config.discord.employee_role_name = ""
@@ -747,7 +782,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertTrue(control_message.deleted)
-        self.assertEqual(reply_message.reactions, [bridge_module.REACTION_FINISHED])
+        self.assertEqual(reply_message.reactions, [])
         self.assertEqual(
             thread.sent_messages,
             [
@@ -1276,7 +1311,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(control_message.deleted)
         self.assertEqual(session.control_message_id, 901)
-        self.assertEqual(reply_message.reactions, [bridge_module.REACTION_IN_PROGRESS])
+        self.assertEqual(reply_message.reactions, [])
         self.assertEqual(
             control_message.reactions,
             [


### PR DESCRIPTION
## Summary
- keep typed Discord replies as a short-lived delivery receipt: initial queued reaction, then clear bot transient reactions after Every Code accepts/progresses
- preserve full queued/in-progress/finished state on the bot-owned control anchor
- keep rejected reply commands visible with the existing rejected reaction

## QA notes for #29
- Existing regression coverage confirmed the stable control-anchor flow for typed replies, TUI-origin user messages, go-ahead reactions, and turn-complete control placement.
- This change applies the #29 learning that the control anchor is the durable control surface, so user-message reactions should stay visually quiet.

## Validation
- uv run python -m unittest tests.test_every_code -q
- uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py
- uv run ruff check --diff discord_blue/doodads/every_code/bridge.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py
- uv run python -m unittest discover -s tests -q
- uv run mypy .
- git diff --check

Refs #29
Closes #28