### PR TITLE
Clean up repo hygiene docs and build config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.code/
+.git/
+.github/
+.idea/
+.mypy_cache/
+.ruff_cache/
+.venv/
+__pycache__/
+*.py[cod]
+.DS_Store
+build/
+dist/
+htmlcov/

--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -6,6 +6,7 @@
     "packageManifest": "pyproject.toml",
     "lockfile": "uv.lock",
     "dockerfile": "Dockerfile",
+    "dockerignore": ".dockerignore",
     "compose": "docker-compose.yml",
     "systemdService": "discord-blue.service"
   },

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,6 @@ jobs:
             "cd /opt/discord-blue; \
           export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring; \
           git pull; \
-          uv sync --all-groups; \
+          uv sync --all-groups --python 3.13; \
           systemctl restart discord-blue"
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,166 +1,27 @@
-### Python template
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
 *.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
+.mypy_cache/
+.ruff_cache/
 .pytest_cache/
-cover/
+.coverage
+htmlcov/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
+# Local environments and secrets
 .env
-.venv
+.venv/
 env/
 venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#  .idea/
-
-# Mac OS
-.DS_Store
-.code/
 *.override.*
+
+# Build output
+build/
+dist/
+
+# Editor and OS files
+.vscode/
+.DS_Store
+
+# Agent-local scratch state
+.code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM ghcr.io/astral-sh/uv:debian
 WORKDIR /app
 
 COPY . ./
-RUN uv sync
+RUN uv sync --all-groups --python 3.13
 
 ENTRYPOINT ["uv", "run", "discord-blue"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Discord Blue LXC Installation Guide
+# Discord Blue
 
 Discord Blue is a basic Discord bot plugin system built with the **discord.py**
-library. This guide provides step-by-step instructions for setting it up on a
-Debian-based LXC.
+library. It includes an Every Code doodad that bridges Discord session threads
+to a local Every Code remote inbox.
 
-## Installation Steps
+## LXC Installation
 
 1. Update System Packages:
 
    ```bash
    apt update && apt upgrade
-   apt install git curl libcairo2
+   apt install git curl
    curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
 
@@ -25,7 +25,7 @@ Debian-based LXC.
 3. Install Dependencies with uv:
 
    ```bash
-   uv sync --all-groups
+   uv sync --all-groups --python 3.13
    ```
 
 4. Set up and Start the Systemd Service:
@@ -45,6 +45,33 @@ the first guild the bot joins, so they appear immediately.
 uv run discord-blue
 ```
 
+To enable Every Code, set the doodad extension name in the generated config:
+
+```toml
+[discord]
+loaded_doodads = ["every_code_doodad"]
+
+[every_code]
+enabled = true
+```
+
+## Development
+
+Install the managed Python environment:
+
+```bash
+uv sync --all-groups --python 3.13
+```
+
+Run the local validation gates:
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy .
+uv run python -m unittest discover -s tests -q
+```
+
 ## Docker
 
 A `Dockerfile` is provided to build a containerized version of the bot. It
@@ -61,4 +88,11 @@ Run the bot:
 
 ```bash
 docker run --rm discord-blue
+```
+
+Or use Docker Compose, which mounts `${HOME}/.config/discord-blue` into the
+container for the generated config:
+
+```bash
+docker compose up -d
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "discord-blue"
 version = "0.2.0"
-description = ""
+description = "Discord bot plugin system with Every Code remote inbox integration"
 authors = [{ name = "Chris Busillo", email = "info@shinycomputers.com" }]
 readme = "README.md"
 
@@ -36,4 +36,3 @@ line-length = 133
 
 [tool.ruff.lint]
 select = ["ANN", "B", "E", "F", "RUF"]
-#ignore = ["ANN401"]

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -80,7 +80,7 @@ class ConfigTests(unittest.TestCase):
                     "guild_id = 1",
                     "bot_channel_id = 2",
                     'employee_role_name = "employee"',
-                    'loaded_doodads = ["every_code"]',
+                    'loaded_doodads = ["every_code_doodad"]',
                     "",
                     "[every_code]",
                     "enabled = true",


### PR DESCRIPTION
## Summary
- refresh README setup docs for Python 3.13, Every Code doodad config, local validation, and Docker Compose
- simplify root ignore rules while preserving committed JetBrains project config, and add .dockerignore for cleaner Docker build contexts
- align Docker and production deploy uv sync commands with the documented Python 3.13 setup
- fill in package description and fix the Every Code doodad name in the config test sample

## Follow-ups Split Out
- #31 tracks TOML/config import-time modernization
- #32 tracks pytest migration evaluation
- #33 tracks systemd runtime hardening for the one active install

## Validation
- uv run ruff format --check .
- uv run ruff check --diff .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q
- uv build
- git diff --check

## Not Run
- docker build -t discord-blue:cleanup-26 . — Docker daemon/socket is not available locally

Closes #26