### PR TITLE
Clear stale Every Code rejection reactions

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -31,6 +31,7 @@ from discord_blue.doodads.every_code.sessions import (
     PendingRemoteApproval,
     PendingRemoteCommand,
     PendingRemoteUserInput,
+    RejectedCommandMessage,
 )
 from discord_blue.doodads.every_code.threads import SessionThread
 from discord_blue.doodads.every_code.threads import auto_join_configured_users
@@ -920,6 +921,13 @@ class EveryCodeBridge:
             session.active_command_id = None
         if command is not None:
             await self.update_command_message_reaction(session, command, REACTION_REJECTED)
+            if command.message_id is not None:
+                session.rejected_command_messages.append(
+                    RejectedCommandMessage(
+                        thread_id=command.thread_id,
+                        message_id=command.message_id,
+                    )
+                )
             if command.reject_notice is not None:
                 reason = str(payload.get("reason") or "command was rejected")
                 await self.post_thread_notice(command.thread_id, f"{command.reject_notice}: {reason}")
@@ -1371,6 +1379,7 @@ class EveryCodeBridge:
         if message_type == "turn_complete" and status.assistant_message:
             await self.post_assistant_message(session.thread_id, status.assistant_message)
         if message_type == "turn_complete":
+            await self.clear_rejected_command_reactions(session)
             await self.update_active_command_reaction(session, REACTION_FINISHED, clear=True)
             await self.clear_pending_user_inputs(
                 session,
@@ -1431,6 +1440,12 @@ class EveryCodeBridge:
             session.active_command_id = None
             if command.message_id == session.control_message_id:
                 session.control_status_reaction = None
+
+    async def clear_rejected_command_reactions(self, session: EveryCodeSession) -> None:
+        rejected_messages = session.rejected_command_messages
+        session.rejected_command_messages = []
+        for rejected_message in rejected_messages:
+            await self.clear_message_transient_reactions(rejected_message.thread_id, rejected_message.message_id)
 
     async def update_session_status_reaction(
         self,
@@ -1611,6 +1626,7 @@ class EveryCodeBridge:
             return
         try:
             message = await channel.fetch_message(message_id)
+            await self.clear_message_reactions(message)
             await message.delete()
         except discord.NotFound:
             return

--- a/discord_blue/doodads/every_code/sessions.py
+++ b/discord_blue/doodads/every_code/sessions.py
@@ -18,6 +18,12 @@ class PendingRemoteCommand:
 
 
 @dataclass(slots=True)
+class RejectedCommandMessage:
+    thread_id: int
+    message_id: int
+
+
+@dataclass(slots=True)
 class PendingRemoteApproval:
     thread_id: int
     message_id: int
@@ -43,6 +49,7 @@ class EveryCodeSession:
     pending_commands: dict[str, PendingRemoteCommand] = field(default_factory=dict)
     pending_approvals: dict[str, PendingRemoteApproval] = field(default_factory=dict)
     pending_user_inputs: dict[str, PendingRemoteUserInput] = field(default_factory=dict)
+    rejected_command_messages: list[RejectedCommandMessage] = field(default_factory=list)
     active_command_id: str | None = None
     last_status_message: str | None = None
     control_status_reaction: str | None = None

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -39,6 +39,7 @@ class FakeReplyMessage:
         self.reply_mentions: list[bool] = []
         self.edits: list[tuple[str, bool]] = []
         self.deleted = False
+        self.delete_raises = False
 
     async def add_reaction(self, reaction: str) -> None:
         self.reactions.append(reaction)
@@ -59,6 +60,11 @@ class FakeReplyMessage:
         self.edits.append((content, kwargs.get("view") is None))
 
     async def delete(self) -> None:
+        if self.delete_raises:
+            raise discord.Forbidden(
+                response=SimpleNamespace(status=403, reason="Forbidden"),
+                message=f"Cannot delete {self.id}",
+            )
         self.deleted = True
         self.channel.delete_message(self.id)
 

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -795,6 +795,80 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(session.control_message_id, 902)
         self.assertFalse(session.control_interruptions_enabled)
 
+    async def test_turn_complete_clears_recovered_rejected_reply_reaction(self) -> None:
+        config = Config()
+        config.discord.employee_role_name = ""
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        websocket = FakeWebSocket()
+        control_message = add_bot_message(thread, 801, "\u200b")
+        control_message.reactions = ["▶️", bridge_module.REACTION_CONTROL_STATUS, "⏹️"]
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=websocket,
+            thread_id=555,
+            control_message_id=801,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+        reply_message = FakeReplyMessage(802, thread, "Run the quick path")
+        thread.add_message(reply_message)
+
+        await bridge.send_thread_reply(cast(Any, reply_message))
+        command_id = next(iter(session.pending_commands))
+        await bridge.handle_command_reject({"session_id": "session-1", "command_id": command_id})
+
+        self.assertEqual(reply_message.reactions, [bridge_module.REACTION_REJECTED])
+        self.assertEqual(len(session.rejected_command_messages), 1)
+
+        await bridge.handle_session_status(
+            "turn_complete",
+            SessionStatus(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                message="Waiting for direction",
+                assistant_message="Recovered.",
+            ),
+        )
+
+        self.assertEqual(reply_message.reactions, [])
+        self.assertEqual(session.rejected_command_messages, [])
+
+    async def test_turn_complete_clears_stale_reactions_before_deleting_old_anchor(self) -> None:
+        config = Config()
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        control_message = add_bot_message(thread, 801, "\u200b")
+        control_message.reactions = [bridge_module.REACTION_REJECTED]
+        control_message.delete_raises = True
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+            control_message_id=801,
+            control_status_reaction=bridge_module.REACTION_REJECTED,
+            control_interruptions_enabled=True,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.handle_session_status(
+            "turn_complete",
+            SessionStatus(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                message="Waiting for direction",
+                assistant_message="Done.",
+            ),
+        )
+
+        self.assertFalse(control_message.deleted)
+        self.assertEqual(control_message.reactions, [])
+        new_control_message = await thread.fetch_message(902)
+        self.assertEqual(new_control_message.reactions, ["▶️", bridge_module.REACTION_CONTROL_STATUS, "⏹️"])
+        self.assertEqual(session.control_message_id, 902)
+        self.assertFalse(session.control_interruptions_enabled)
+
     async def test_turn_complete_restores_reaction_controls_on_existing_anchor(self) -> None:
         config = Config()
         thread = FakeThread(555)


### PR DESCRIPTION
## Summary
- remember rejected command message receipts until the next successful turn completion so recovered turns can clear stale red-X reactions
- clear reactions from an old control anchor before deleting it, so a failed Discord delete cannot leave stale active/error controls behind
- add regression coverage for rejected reply recovery and undeletable old control anchors

## Validation
- uv run python -m unittest tests.test_every_code -q
- uv run ruff format --check discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/sessions.py tests/fakes_every_code.py tests/test_every_code.py
- uv run ruff check --diff discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/sessions.py tests/fakes_every_code.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/sessions.py tests/fakes_every_code.py tests/test_every_code.py
- uv run mypy .
- uv run python -m unittest discover -s tests -q
- git diff --check

Refs #35