### PR TITLE
Harden systemd service runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,9 @@
 .mypy_cache/
 .ruff_cache/
 .venv/
+.venv-next/
+.venv-prev/
+.uv-python/
 __pycache__/
 *.py[cod]
 .DS_Store

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,15 +61,25 @@ jobs:
           service_home=/var/lib/discord-blue
           config_path=$service_home/.config/discord-blue/config.toml
           root_config=/root/.config/discord-blue/config.toml
+          if ! getent group "$service_user" >/dev/null; then
+            groupadd --system "$service_user"
+          fi
           if ! id -u "$service_user" >/dev/null 2>&1; then
             useradd --system --home-dir "$service_home" --create-home \
-              --shell /usr/sbin/nologin "$service_user"
+              --gid "$service_user" --shell /usr/sbin/nologin \
+              "$service_user"
           fi
+          install -d -m 700 -o "$service_user" -g "$service_user" \
+            "$service_home"
           install -d -m 700 -o "$service_user" -g "$service_user" \
             "$(dirname "$config_path")"
           if [ ! -f "$config_path" ] && [ -f "$root_config" ]; then
             install -D -m 600 -o "$service_user" -g "$service_user" \
               "$root_config" "$config_path"
+          fi
+          if [ ! -e "$service_home/.code" ] && [ -e /root/.code ]; then
+            cp -a /root/.code "$service_home/.code"
+            chown -R "$service_user:$service_user" "$service_home/.code"
           fi
           cd /opt/discord-blue
           export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,46 @@ jobs:
         run: |
           ssh \
             ${{ vars.PRODUCTION_USER }}@${{ vars.PRODUCTION_SERVER }} \
-            "cd /opt/discord-blue; \
-          export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring; \
-          git pull; \
-          uv sync --all-groups --python 3.13; \
-          systemctl restart discord-blue"
+            <<'REMOTE'
+          set -eu
+          service_user=discord-blue
+          service_home=/var/lib/discord-blue
+          config_path=$service_home/.config/discord-blue/config.toml
+          root_config=/root/.config/discord-blue/config.toml
+          if ! id -u "$service_user" >/dev/null 2>&1; then
+            useradd --system --home-dir "$service_home" --create-home \
+              --shell /usr/sbin/nologin "$service_user"
+          fi
+          install -d -m 700 -o "$service_user" -g "$service_user" \
+            "$(dirname "$config_path")"
+          if [ ! -f "$config_path" ] && [ -f "$root_config" ]; then
+            install -D -m 600 -o "$service_user" -g "$service_user" \
+              "$root_config" "$config_path"
+          fi
+          cd /opt/discord-blue
+          export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+          export UV_PYTHON_INSTALL_DIR=/opt/discord-blue/.uv-python
+          git pull
+          install -d -m 755 .uv-python
+          uv python install 3.13
+          rm -rf .venv-next
+          UV_PROJECT_ENVIRONMENT=/opt/discord-blue/.venv-next \
+            uv sync --all-groups --python 3.13
+          chmod -R a+rX .uv-python .venv-next
+          rm -rf .venv-prev
+          if [ -d .venv ]; then
+            mv .venv .venv-prev
+          fi
+          mv .venv-next .venv
+          old_shebang='^#!/opt/discord-blue/.venv-next/bin/python'
+          new_shebang='#!/opt/discord-blue/.venv/bin/python'
+          for script in $(grep -rl "$old_shebang" .venv/bin || true); do
+            sed -i "1s|$old_shebang$|$new_shebang|" "$script"
+          done
+          cp discord-blue.service /etc/systemd/system/discord-blue.service
+          systemctl daemon-reload
+          systemctl enable discord-blue
+          systemctl restart discord-blue
+          rm -rf .venv-prev
+          REMOTE
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ htmlcov/
 # Local environments and secrets
 .env
 .venv/
+.venv-next/
+.venv-prev/
+.uv-python/
 env/
 venv/
 *.override.*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ to a local Every Code remote inbox.
    curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
 
-2. Clone the Discord Blue Repository:
+2. Create the service user:
+
+   ```bash
+   useradd --system --home-dir /var/lib/discord-blue --create-home \
+     --shell /usr/sbin/nologin discord-blue
+   install -d -m 700 -o discord-blue -g discord-blue /var/lib/discord-blue/.config/discord-blue
+   ```
+
+3. Clone the Discord Blue Repository:
 
    ```bash
    cd /opt
@@ -22,13 +30,35 @@ to a local Every Code remote inbox.
    cd discord-blue
    ```
 
-3. Install Dependencies with uv:
+4. Install Dependencies with uv:
 
    ```bash
+   export UV_PYTHON_INSTALL_DIR=/opt/discord-blue/.uv-python
+   uv python install 3.13
+   rm -rf .venv
    uv sync --all-groups --python 3.13
+   chmod -R a+rX .uv-python .venv
    ```
 
-4. Set up and Start the Systemd Service:
+5. Create or migrate the config.
+
+   For a new install, run the bot once as the service user and complete the
+   prompts:
+
+   ```bash
+   sudo -u discord-blue HOME=/var/lib/discord-blue \
+     /opt/discord-blue/.venv/bin/discord-blue
+   ```
+
+   For the existing root-based install, migrate the generated config instead:
+
+   ```bash
+   install -D -m 600 -o discord-blue -g discord-blue \
+     /root/.config/discord-blue/config.toml \
+     /var/lib/discord-blue/.config/discord-blue/config.toml
+   ```
+
+6. Set up and Start the Systemd Service:
 
    ```bash
    cp discord-blue.service /etc/systemd/system/
@@ -37,13 +67,9 @@ to a local Every Code remote inbox.
    systemctl start discord-blue
    ```
 
-**Note**: Make sure to run once to create the config file and input the Discord
-token along with the server and the bot channel. Slash commands sync directly to
-the first guild the bot joins, so they appear immediately.
-
-```bash
-uv run discord-blue
-```
+**Note**: The systemd service runs as the `discord-blue` user and reads config
+from `/var/lib/discord-blue/.config/discord-blue/config.toml`. Slash commands
+sync directly to the first guild the bot joins, so they appear immediately.
 
 To enable Every Code, set the doodad extension name in the generated config:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ to a local Every Code remote inbox.
 2. Create the service user:
 
    ```bash
+   groupadd --system discord-blue
    useradd --system --home-dir /var/lib/discord-blue --create-home \
-     --shell /usr/sbin/nologin discord-blue
+     --gid discord-blue --shell /usr/sbin/nologin discord-blue
    install -d -m 700 -o discord-blue -g discord-blue /var/lib/discord-blue/.config/discord-blue
    ```
 
@@ -56,6 +57,10 @@ to a local Every Code remote inbox.
    install -D -m 600 -o discord-blue -g discord-blue \
      /root/.config/discord-blue/config.toml \
      /var/lib/discord-blue/.config/discord-blue/config.toml
+   if [ ! -e /var/lib/discord-blue/.code ] && [ -e /root/.code ]; then
+     cp -a /root/.code /var/lib/discord-blue/.code
+     chown -R discord-blue:discord-blue /var/lib/discord-blue/.code
+   fi
    ```
 
 6. Set up and Start the Systemd Service:

--- a/discord-blue.service
+++ b/discord-blue.service
@@ -5,17 +5,22 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-# Use the same Python version installed with uv venv
-ExecStart=uv run discord-blue
-User=root
-Group=root
-Type=idle
-Restart=on-abnormal
-RestartSec=15
-RestartForceExitStatus=1
-RestartForceExitStatus=26
-TimeoutStopSec=10
+Type=simple
+User=discord-blue
+Group=discord-blue
 WorkingDirectory=/opt/discord-blue
+Environment=HOME=/var/lib/discord-blue
+ExecStart=/opt/discord-blue/.venv/bin/discord-blue
+Restart=on-failure
+RestartSec=15
+TimeoutStopSec=10
+StateDirectory=discord-blue
+StateDirectoryMode=0700
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- run `discord-blue.service` as a dedicated `discord-blue` service user instead of root
- create the `discord-blue` group explicitly before creating the user
- use `/var/lib/discord-blue` as the stable service home/config location and run the installed `.venv` entrypoint directly
- preserve legacy `/root/.code` state by copying it to `/var/lib/discord-blue/.code` when present and missing from the service home
- install uv-managed Python under `/opt/discord-blue/.uv-python` so the non-root service does not depend on root's home directory
- build `.venv-next` first, then swap it into `.venv` only after sync succeeds
- rewrite generated console-script shebangs from `.venv-next` to `.venv` after the swap
- add conservative systemd sandboxing (`NoNewPrivileges`, `PrivateTmp`, `ProtectHome`, `ProtectSystem`, private state dir, restrictive umask)
- update the deploy workflow to migrate the one active install idempotently before restart
- document fresh install and existing root-config/state migration steps in README

## Production migration behavior on merge
The deploy job will run these one-time-safe steps on the target host before restart:
- create `discord-blue` system group if missing
- create `discord-blue` system user if missing
- create `/var/lib/discord-blue/.config/discord-blue` owned by `discord-blue`
- if the new config is missing and `/root/.config/discord-blue/config.toml` exists, copy it to the service user's config path with mode `600`
- if `/root/.code` exists and `/var/lib/discord-blue/.code` is missing, copy it and chown it to `discord-blue:discord-blue`
- install Python under `/opt/discord-blue/.uv-python`
- build the project into `/opt/discord-blue/.venv-next`, rewrite generated script shebangs, then swap it into `/opt/discord-blue/.venv`
- copy `discord-blue.service` into `/etc/systemd/system/discord-blue.service`
- run `systemctl daemon-reload`, `systemctl enable discord-blue`, and `systemctl restart discord-blue`

## Host validation on discord-blue.shiny
- confirmed current host was active/enabled and running the old root service before migration
- confirmed `/root/.config/discord-blue/config.toml` existed and new service-user config did not yet exist
- confirmed `PRODUCTION_USER` is `root`
- confirmed the proposed service unit passes `systemd-analyze verify` on the host
- confirmed root's old `.venv/bin/python` pointed into `/root/.local/share/uv`, which would fail under non-root + `ProtectHome=true`
- confirmed using `UV_PYTHON_INSTALL_DIR=/opt/discord-blue/...` builds a venv whose Python lives under `/opt`
- confirmed a transient non-root systemd unit can execute that `/opt` Python with `NoNewPrivileges`, `PrivateTmp`, `ProtectHome`, and `ProtectSystem=full`
- manually applied the migration on `discord-blue.shiny`; initial restart exposed the `.venv-next` shebang issue, then shebang rewrite fixed it
- confirmed `/root/.code` did not exist on the host, so no legacy Every Code state needed migration there
- confirmed the live service is now active, enabled, running as `discord-blue`, using `/opt/discord-blue/.uv-python/.../python3.13`, listening on `0.0.0.0:8787`, and reading `/var/lib/discord-blue/.config/discord-blue/config.toml` owned `discord-blue:discord-blue` mode `600`

## Validation
- `uv run ruff format --check .`
- `uv run ruff check --diff .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run python -m unittest discover -s tests -q`
- `git diff --check`
- `markdownlint-cli2 README.md`
- `yamllint .github/workflows/main.yml`
- `actionlint .github/workflows/main.yml`

Refs #33
