### PR TITLE
Modernize config TOML handling

### DIFF
--- a/discord_blue/__main__.py
+++ b/discord_blue/__main__.py
@@ -8,7 +8,7 @@ from time import sleep
 
 from discord.errors import PrivilegedIntentsRequired
 
-from discord_blue.config import config
+from discord_blue.config import get_config
 from discord_blue.plugs.discord_plug import BlueBot
 
 DISCORD_TOKEN_TIMEOUT = 120
@@ -48,12 +48,13 @@ def parse_args() -> Namespace:
 
 
 def start_bot() -> None:
+    config = get_config()
     login_success = False
     for _count in range(DISCORD_TOKEN_TIMEOUT):
         if login_success:
             break
         try:
-            bot = BlueBot()
+            bot = BlueBot(config)
             loop = asyncio.get_event_loop()
             handler = create_signal_handler(bot)
             for signal_to_add in (signal.SIGINT, signal.SIGTERM):

--- a/discord_blue/config.py
+++ b/discord_blue/config.py
@@ -1,9 +1,9 @@
 import logging
+import tomllib
 from pathlib import Path
 from typing import Any
 
-# noinspection PyPackageRequirements
-import toml
+import tomli_w
 
 logger = logging.getLogger(__name__)
 
@@ -103,8 +103,8 @@ class Config(Serializable):
 
     def load(self) -> None:
         try:
-            with self.filepath.open() as file:
-                data = toml.load(file)
+            with self.filepath.open("rb") as file:
+                data = tomllib.load(file)
                 for key, value in data.items():
                     if key.startswith("_"):
                         continue
@@ -116,7 +116,7 @@ class Config(Serializable):
                         attr.from_dict(value)
                     else:
                         setattr(self, key, value)
-        except (FileNotFoundError, OSError, toml.TomlDecodeError):
+        except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
             logger.exception("Error loading configuration")
             exit(1)
         self.save()
@@ -125,7 +125,7 @@ class Config(Serializable):
         self.gather_missing_data(self)
         data = self.to_dict()
         try:
-            toml_data = toml.dumps(data)
+            toml_data = tomli_w.dumps(data)
             self.filepath.write_text(toml_data)
         except KeyError as key_error:
             logger.error(f"KeyError when saving configuration: {key_error}")
@@ -163,8 +163,10 @@ class Config(Serializable):
                     Config.gather_missing_data(value, full_key_name)
 
 
-config = Config()
+def get_config() -> Config:
+    return Config.get_instance()
+
 
 if __name__ == "__main__":
-    config = Config.get_instance()
-    print(config.discord.token)
+    loaded_config = get_config()
+    print(loaded_config.discord.token)

--- a/discord_blue/plugs/discord/checks.py
+++ b/discord_blue/plugs/discord/checks.py
@@ -4,7 +4,6 @@ from typing import Any, Callable
 import discord
 from discord import app_commands
 
-from discord_blue.config import config
 from discord_blue.plugs.discord_plug import BlueBot
 
 logger = logging.getLogger(__name__)
@@ -13,7 +12,7 @@ logger = logging.getLogger(__name__)
 def has_employee_role() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     async def predicate(interaction: discord.Interaction[BlueBot]) -> bool:
         if isinstance(interaction.user, discord.Member):
-            result = any(role.name == config.discord.employee_role_name for role in interaction.user.roles)
+            result = any(role.name == interaction.client.config.discord.employee_role_name for role in interaction.user.roles)
             return result
         return False
 

--- a/discord_blue/plugs/discord_plug.py
+++ b/discord_blue/plugs/discord_plug.py
@@ -6,7 +6,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import Bot
 
-from discord_blue.config import config
+from discord_blue.config import Config
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=discord.Guild | discord.TextChannel)
@@ -16,7 +16,7 @@ class BlueBot(commands.Bot):
     destination_guild: discord.Guild
     bot_channel: discord.TextChannel
 
-    def __init__(self) -> None:
+    def __init__(self, config: Config) -> None:
         self.config = config
         intents = discord.Intents.all()
 
@@ -45,20 +45,20 @@ class BlueBot(commands.Bot):
         await self.close()
 
     async def blue_guild(self) -> discord.Guild:
-        if not config.discord.guild_id:
+        if not self.config.discord.guild_id:
             return await self.select_object(list(self.guilds), "guild", self.save_config_guild)
-        if guild := self.get_guild(config.discord.guild_id):
+        if guild := self.get_guild(self.config.discord.guild_id):
             return guild
-        self.message_and_raise_error(f"Could not find guild with ID {config.discord.guild_id}")
+        self.message_and_raise_error(f"Could not find guild with ID {self.config.discord.guild_id}")
 
     async def blue_bot_channel(self, guild: discord.Guild) -> discord.TextChannel:
-        if not config.discord.bot_channel_id:
+        if not self.config.discord.bot_channel_id:
             return await self.select_object(list(guild.text_channels), "channel", self.save_config_bot_channel)
-        if channel := self.get_channel(config.discord.bot_channel_id):
+        if channel := self.get_channel(self.config.discord.bot_channel_id):
             if isinstance(channel, discord.TextChannel):
                 return channel
 
-        self.message_and_raise_error(f"Could not find channel with ID {config.discord.bot_channel_id}")
+        self.message_and_raise_error(f"Could not find channel with ID {self.config.discord.bot_channel_id}")
 
     @staticmethod
     def message_and_raise_error(message: str, error_type: type[BaseException] = ValueError) -> NoReturn:
@@ -81,15 +81,13 @@ class BlueBot(commands.Bot):
             except ValueError:
                 print("Invalid input. Please use the index number.")
 
-    @staticmethod
-    def save_config_guild(guild: discord.Guild) -> None:
-        config.discord.guild_id = guild.id
-        config.save()
+    def save_config_guild(self, guild: discord.Guild) -> None:
+        self.config.discord.guild_id = guild.id
+        self.config.save()
 
-    @staticmethod
-    def save_config_bot_channel(channel: discord.TextChannel) -> None:
-        config.discord.bot_channel_id = channel.id
-        config.save()
+    def save_config_bot_channel(self, channel: discord.TextChannel) -> None:
+        self.config.discord.bot_channel_id = channel.id
+        self.config.save()
 
     @staticmethod
     async def wrap_reply_lines(lines: str, message: discord.Message | discord.Interaction[Bot]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,13 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiohttp",
-    "toml",
+    "tomli-w",
     "discord.py",
     "PyNaCl",
 ]
 
 [dependency-groups]
 dev = [
-    "types-toml",
     "mypy",
     "hatchling",
     "ruff",

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import importlib
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -71,6 +73,22 @@ def stub_recovered_assistant_message(bridge: object, recovered_message: str | No
 
 
 class ConfigTests(unittest.TestCase):
+    def test_config_module_import_has_no_filesystem_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            result = subprocess.run(
+                [sys.executable, "-c", "import discord_blue.config"],
+                cwd=Path(__file__).parents[1],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((Path(home) / ".config" / "discord-blue" / "config.toml").exists())
+
     def test_every_code_config_loads_and_saves(self) -> None:
         _CONFIG_PATH.write_text(
             "\n".join(

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "discord-py" },
     { name = "pynacl" },
-    { name = "toml" },
+    { name = "tomli-w" },
 ]
 
 [package.dev-dependencies]
@@ -221,7 +221,6 @@ dev = [
     { name = "hatchling" },
     { name = "mypy" },
     { name = "ruff" },
-    { name = "types-toml" },
 ]
 
 [package.metadata]
@@ -229,7 +228,7 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "discord-py" },
     { name = "pynacl" },
-    { name = "toml" },
+    { name = "tomli-w" },
 ]
 
 [package.metadata.requires-dev]
@@ -237,7 +236,6 @@ dev = [
     { name = "hatchling" },
     { name = "mypy" },
     { name = "ruff" },
-    { name = "types-toml" },
 ]
 
 [[package]]
@@ -689,12 +687,12 @@ wheels = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
+name = "tomli-w"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -704,15 +702,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz", hash = "sha256:00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3", size = 16997, upload-time = "2026-01-14T14:54:50.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl", hash = "sha256:1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d", size = 14197, upload-time = "2026-01-14T14:54:49.067Z" },
-]
-
-[[package]]
-name = "types-toml"
-version = "0.10.8.20260408"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the legacy toml dependency with stdlib tomllib for reads and tomli-w for writes
- remove import-time Config() creation and make the app entrypoint create/pass runtime config explicitly
- update Discord role checks and bot config saves to use the bot-owned config object
- add a regression test proving importing discord_blue.config does not create a config file

Closes #31.

## Validation
- uv run python -m unittest discover -s tests -q
- uv run ruff format --check --diff .
- uv run ruff check .
- uv run mypy .