### PR TITLE
Fix graceful Every Code bridge shutdown

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -46,6 +46,8 @@ DISCORD_MESSAGE_LIMIT = 2000
 DISCORD_ASSISTANT_CHUNK_LIMIT = 1800
 DISCORD_CODE_FENCE_WRAP_RESERVE = 80
 STARTUP_RECONNECT_GRACE_SECONDS = 20
+SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = 2
+SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS = 5
 SESSION_START_PREFIX = "Every Code session connected"
 SESSION_NOTIFICATION_PREFIX = "Every Code session connected for "
 MARKDOWN_CODE_FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?P<info>[^`~\n]*)$")
@@ -266,7 +268,7 @@ class EveryCodeBridge:
 
         app = web.Application()
         app.router.add_get("/every-code/connect", self.handle_connect)
-        self._runner = web.AppRunner(app)
+        self._runner = web.AppRunner(app, shutdown_timeout=SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS)
         await self._runner.setup()
         self._site = web.TCPSite(
             self._runner,
@@ -295,9 +297,27 @@ class EveryCodeBridge:
             with suppress(asyncio.CancelledError):
                 await self._heartbeat_task
             self._heartbeat_task = None
-        await self._runner.cleanup()
-        self._runner = None
-        self._site = None
+        await self.disconnect_active_sessions()
+        try:
+            await asyncio.wait_for(self._runner.cleanup(), timeout=SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS)
+        except TimeoutError:
+            logger.warning("Every Code bridge runner cleanup timed out during shutdown")
+        finally:
+            self._runner = None
+            self._site = None
+
+    async def disconnect_active_sessions(self) -> None:
+        for session_id in list(self.sessions.by_session):
+            session = self.sessions.remove(session_id)
+            if session is None or session.websocket.closed:
+                continue
+            try:
+                await asyncio.wait_for(
+                    session.websocket.close(message=b"bridge shutdown", drain=False),
+                    timeout=SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                logger.warning("Unable to close Every Code websocket %s during shutdown", session_id, exc_info=True)
 
     async def close_active_sessions(self) -> None:
         for session_id in list(self.sessions.by_session):

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -16,9 +16,15 @@ class FakeWebSocket:
     def __init__(self, *, closed: bool = False) -> None:
         self.closed = closed
         self.sent_json: list[dict[str, object]] = []
+        self.close_messages: list[bytes] = []
 
     async def send_json(self, payload: dict[str, object]) -> None:
         self.sent_json.append(payload)
+
+    async def close(self, *, message: bytes = b"", drain: bool = True) -> bool:
+        self.close_messages.append(message)
+        self.closed = True
+        return True
 
 
 class FakeReplyMessage:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import importlib
@@ -351,6 +352,74 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(bridge._authorized(SimpleNamespace(headers={})))
         self.assertFalse(bridge._authorized(SimpleNamespace(headers={"Authorization": "Bearer wrong"})))
         self.assertTrue(bridge._authorized(SimpleNamespace(headers={"Authorization": "Bearer shared-secret"})))
+
+    async def test_stop_disconnects_sessions_before_runner_cleanup(self) -> None:
+        config = Config()
+        bridge = EveryCodeBridge(FakeBot(config))
+        websocket = FakeWebSocket()
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=websocket,
+            thread_id=555,
+            notification_message_id=777,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555, notification_message_id=777)
+        test_case = self
+
+        class FakeRunner:
+            def __init__(self) -> None:
+                self.cleaned = False
+
+            async def cleanup(self) -> None:
+                self.cleaned = True
+                test_case.assertTrue(websocket.closed)
+                test_case.assertIsNone(bridge.sessions.get("session-1"))
+
+        runner = FakeRunner()
+        cast(Any, bridge)._runner = runner
+
+        await bridge.stop()
+
+        self.assertTrue(runner.cleaned)
+        self.assertTrue(websocket.closed)
+        self.assertEqual(websocket.close_messages, [b"bridge shutdown"])
+        self.assertIsNone(bridge.sessions.get("session-1"))
+        self.assertIsNone(bridge.sessions.get_by_thread(555))
+        self.assertIsNone(cast(Any, bridge)._runner)
+
+    async def test_stop_bounds_slow_runner_cleanup(self) -> None:
+        config = Config()
+        bridge = EveryCodeBridge(FakeBot(config))
+
+        class SlowRunner:
+            def __init__(self) -> None:
+                self.cleanup_started = False
+                self.cleanup_cancelled = False
+
+            async def cleanup(self) -> None:
+                self.cleanup_started = True
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    self.cleanup_cancelled = True
+                    raise
+
+        runner = SlowRunner()
+        bridge_module_any = cast(Any, bridge_module)
+        original_timeout = bridge_module_any.SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS
+        bridge_module_any.SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS = 0.01
+        cast(Any, bridge)._runner = runner
+        try:
+            with self.assertLogs(cast(Any, bridge_module).logger, level="WARNING") as logs:
+                await bridge.stop()
+        finally:
+            bridge_module_any.SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS = original_timeout
+
+        self.assertIn("Every Code bridge runner cleanup timed out during shutdown", "\n".join(logs.output))
+        self.assertTrue(runner.cleanup_started)
+        self.assertTrue(runner.cleanup_cancelled)
+        self.assertIsNone(cast(Any, bridge)._runner)
 
     async def test_thread_reply_routes_to_registered_session_websocket(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- close registered Every Code bridge websockets before aiohttp runner cleanup during shutdown
- bound websocket close and runner cleanup time so SIGTERM can finish inside the systemd stop window
- add regression tests for shutdown ordering and slow runner cleanup timeout

Refs #40.

## Validation
- `uv run python -m unittest discover -s tests -q`
- `uv run ruff format --check --diff .`
- `uv run ruff check .`
- `uv run mypy .`

## Notes
Manual production validation still needs to happen after merge: restart `discord-blue.service` on `discord-blue.shiny` and confirm the journal no longer shows stop timeout/SIGKILL.
