### PR TITLE
Record pytest evaluation through test isolation

### DIFF
--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -25,29 +25,35 @@ _TEST_HOME = tempfile.TemporaryDirectory()
 os.environ["HOME"] = _TEST_HOME.name
 _CONFIG_PATH = Path(_TEST_HOME.name) / ".config" / "discord-blue" / "config.toml"
 _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-_CONFIG_PATH.write_text(
-    "\n".join(
-        [
-            "[discord]",
-            'token = "from-test"',
-            "guild_id = 1",
-            "bot_channel_id = 2",
-            'employee_role_name = "employee"',
-            "loaded_doodads = []",
-            "",
-            "[every_code]",
-            "enabled = false",
-            'listen_host = "0.0.0.0"',
-            "listen_port = 8787",
-            'token = ""',
-            "channel_id = 0",
-            'operator_role_name = ""',
-            "auto_join_user_ids = []",
-            "heartbeat_timeout_seconds = 120",
-            "heartbeat_check_interval_seconds = 30",
-        ]
+
+
+def write_default_config() -> None:
+    _CONFIG_PATH.write_text(
+        "\n".join(
+            [
+                "[discord]",
+                'token = "from-test"',
+                "guild_id = 1",
+                "bot_channel_id = 2",
+                'employee_role_name = "employee"',
+                "loaded_doodads = []",
+                "",
+                "[every_code]",
+                "enabled = false",
+                'listen_host = "0.0.0.0"',
+                "listen_port = 8787",
+                'token = ""',
+                "channel_id = 0",
+                'operator_role_name = ""',
+                "auto_join_user_ids = []",
+                "heartbeat_timeout_seconds = 120",
+                "heartbeat_check_interval_seconds = 30",
+            ]
+        )
     )
-)
+
+
+write_default_config()
 
 Config = importlib.import_module("discord_blue.config").Config
 bridge_module = importlib.import_module("discord_blue.doodads.every_code.bridge")
@@ -74,6 +80,9 @@ def stub_recovered_assistant_message(bridge: object, recovered_message: str | No
 
 
 class ConfigTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        write_default_config()
+
     def test_config_module_import_has_no_filesystem_side_effects(self) -> None:
         with tempfile.TemporaryDirectory() as home:
             env = os.environ.copy()
@@ -335,6 +344,7 @@ class FakeThreadTests(unittest.IsolatedAsyncioTestCase):
 # noinspection DuplicatedCode
 class BridgeTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
+        write_default_config()
         self.original_thread_type = bridge_module.discord.Thread
         self.original_text_channel_type = bridge_module.discord.TextChannel
         bridge_module.discord.Thread = FakeThread


### PR DESCRIPTION
## Summary
- reset the shared test config fixture before bridge tests so suite behavior does not depend on runner/order
- reset the config test fixture after config-specific mutation
- record the #32 decision in this PR: keep the repo on `unittest` for now; do not add pytest until we are ready for a real fixture/parametrize migration

Closes #32.

## Decision
A temporary pytest run originally exposed hidden config-file coupling: 15 tests failed because `ConfigTests` left `operator_role_name` and `auto_join_user_ids` in the shared config file. After isolating that fixture state, both the existing `unittest` runner and a temporary pytest runner pass.

That means pytest can run the suite, but adopting it as a runner-only dependency does not reduce maintenance friction. The next meaningful pytest step would be a real migration of repeated bridge setup into fixtures and parametrized reaction/control cases, which is larger than this issue needs.

## Validation
- `uv run python -m unittest discover -s tests -q`
- `uv run --with pytest pytest -q`
- `uv run ruff format --check --diff .`
- `uv run ruff check .`
- `uv run mypy .`

## Docs
No README/CI command change: the official repo test command remains `uv run python -m unittest discover -s tests -q`.
