### PR TITLE
Close Every Code bridge sessions concurrently

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -307,17 +307,24 @@ class EveryCodeBridge:
             self._site = None
 
     async def disconnect_active_sessions(self) -> None:
+        close_tasks: list[asyncio.Task[None]] = []
         for session_id in list(self.sessions.by_session):
             session = self.sessions.remove(session_id)
             if session is None or session.websocket.closed:
                 continue
-            try:
-                await asyncio.wait_for(
-                    session.websocket.close(message=b"bridge shutdown", drain=False),
-                    timeout=SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS,
-                )
-            except Exception:
-                logger.warning("Unable to close Every Code websocket %s during shutdown", session_id, exc_info=True)
+            close_tasks.append(asyncio.create_task(self.close_session_websocket(session_id, session)))
+
+        if close_tasks:
+            await asyncio.gather(*close_tasks)
+
+    async def close_session_websocket(self, session_id: str, session: EveryCodeSession) -> None:
+        try:
+            await asyncio.wait_for(
+                session.websocket.close(message=b"bridge shutdown", drain=False),
+                timeout=SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.warning("Unable to close Every Code websocket %s during shutdown", session_id, exc_info=True)
 
     async def close_active_sessions(self) -> None:
         for session_id in list(self.sessions.by_session):

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -398,6 +398,60 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(bridge.sessions.get_by_thread(555))
         self.assertIsNone(cast(Any, bridge)._runner)
 
+    async def test_stop_disconnects_sessions_concurrently(self) -> None:
+        config = Config()
+        bridge = EveryCodeBridge(FakeBot(config))
+        all_closes_started = asyncio.Event()
+        started_closes = 0
+        session_count = 3
+
+        class CoordinatedWebSocket(FakeWebSocket):
+            async def close(self, *, message: bytes = b"", drain: bool = True) -> bool:
+                nonlocal started_closes
+                started_closes += 1
+                if started_closes == session_count:
+                    all_closes_started.set()
+                await all_closes_started.wait()
+                return await super().close(message=message, drain=drain)
+
+        websockets: list[CoordinatedWebSocket] = []
+        for index in range(session_count):
+            websocket = CoordinatedWebSocket()
+            websockets.append(websocket)
+            session_id = f"session-{index}"
+            session = EveryCodeSession(
+                hello=SessionHello(
+                    session_id=session_id,
+                    session_epoch="epoch-1",
+                    host_label="Mac Studio",
+                    cwd="/tmp/project",
+                    branch="main",
+                    pid=42,
+                ),
+                websocket=websocket,
+                thread_id=555 + index,
+            )
+            bridge.sessions.register(session)
+            bridge.sessions.bind_thread(session_id, 555 + index)
+
+        class FakeRunner:
+            async def cleanup(self) -> None:
+                pass
+
+        bridge_module_any = cast(Any, bridge_module)
+        original_timeout = bridge_module_any.SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS
+        bridge_module_any.SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = 0.25
+        cast(Any, bridge)._runner = FakeRunner()
+        try:
+            await bridge.stop()
+        finally:
+            bridge_module_any.SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = original_timeout
+
+        self.assertEqual(started_closes, session_count)
+        for websocket in websockets:
+            self.assertEqual(websocket.close_messages, [b"bridge shutdown"])
+            self.assertTrue(websocket.closed)
+
     async def test_stop_bounds_slow_runner_cleanup(self) -> None:
         config = Config()
         bridge = EveryCodeBridge(FakeBot(config))


### PR DESCRIPTION
## Summary
- close active Every Code websocket sessions concurrently during shutdown
- keep each websocket close individually bounded by the existing shutdown timeout
- add a regression test that requires all session close attempts to start before any can finish

Refs #40.

## Validation
- `uv run python -m unittest tests.test_every_code.BridgeTests.test_stop_disconnects_sessions_before_runner_cleanup tests.test_every_code.BridgeTests.test_stop_disconnects_sessions_concurrently tests.test_every_code.BridgeTests.test_stop_bounds_slow_runner_cleanup -q`
- `uv run python -m unittest discover -s tests -q`
- `uv run ruff format --check --diff .`
- `uv run ruff check .`
- `uv run mypy .`

## Notes
Late auto-review correctly caught that the previous shutdown fix still closed sessions sequentially. This keeps shutdown bounded when several Every Code sessions are connected.
