### PR TITLE
Prepare Discord Blue container artifact

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+---
+self-hosted-runner:
+  labels:
+    - chris-testing
+    - chris-testing-discord-blue

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
 
   deploy:
     needs: image
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on:
       - self-hosted
       - chris-testing

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ jobs:
   validate:
     runs-on:
       - self-hosted
-      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
+      - chris-testing
+      - chris-testing-discord-blue
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,7 +40,8 @@ jobs:
     needs: validate
     runs-on:
       - self-hosted
-      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
+      - chris-testing
+      - chris-testing-discord-blue
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -77,7 +79,8 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on:
       - self-hosted
-      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
+      - chris-testing
+      - chris-testing-discord-blue
     steps:
       - name: Setup Tailscale VPN
         uses: tailscale/github-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,9 @@ permissions:
   packages: write
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,7 +37,9 @@ jobs:
 
   image:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,7 +75,9 @@ jobs:
   deploy:
     needs: image
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ${{ vars.DISCORD_BLUE_RUNNER_LABEL }}
     steps:
       - name: Setup Tailscale VPN
         uses: tailscale/github-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ name: Deploy to Production
       - main
 permissions:
   contents: read
+  packages: write
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -32,8 +33,43 @@ jobs:
       - name: Test
         run: uv run python -m unittest discover -s tests -q
 
-  deploy:
+  image:
     needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set image metadata
+        id: image
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/discord-blue"
+          {
+            echo "image=$image"
+            echo "tag_sha=$image:${GITHUB_SHA}"
+            echo "tag_main=$image:main"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+      - name: Build container image
+        run: docker build --tag ${{ steps.image.outputs.tag_sha }} .
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push container image
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push ${{ steps.image.outputs.tag_sha }}
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            docker tag ${{ steps.image.outputs.tag_sha }} ${{ steps.image.outputs.tag_main }}
+            docker push ${{ steps.image.outputs.tag_main }}
+          fi
+        shell: bash
+
+  deploy:
+    needs: image
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,21 @@ FROM ghcr.io/astral-sh/uv:debian
 
 WORKDIR /app
 
-COPY . ./
-RUN uv sync --all-groups --python 3.13
+ENV HOME=/var/lib/discord-blue
+ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT ["uv", "run", "discord-blue"]
+COPY . ./
+RUN uv sync --frozen --no-dev --python 3.13 \
+    && groupadd --system discord-blue \
+    && useradd --system --home-dir /var/lib/discord-blue --no-create-home \
+        --gid discord-blue --shell /usr/sbin/nologin discord-blue \
+    && install -d -m 700 -o discord-blue -g discord-blue \
+        /var/lib/discord-blue/.config/discord-blue \
+    && install -m 755 docker/entrypoint.sh /usr/local/bin/discord-blue-entrypoint \
+    && chown -R discord-blue:discord-blue /app
+
+VOLUME ["/var/lib/discord-blue"]
+EXPOSE 8787
+
+ENTRYPOINT ["/usr/local/bin/discord-blue-entrypoint"]
+CMD ["/app/.venv/bin/discord-blue"]

--- a/README.md
+++ b/README.md
@@ -159,8 +159,13 @@ unit, and restarts the service. The container migration target is narrower:
 Until Launchplane owns the deploy driver, the existing SSH/systemd workflow
 remains the production deployment path.
 
-GitHub Actions expects a repository variable named `DISCORD_BLUE_RUNNER_LABEL`
-that points at the self-hosted runner label authorized for this repo. Other
-operational repos use repo-specific labels such as `chris-testing-launchplane`,
-`chris-testing-verireel`, or `chris-testing-sellyouroutboard`; Discord Blue
-should follow that pattern before the container workflow is treated as mergeable.
+GitHub Actions expects repo-scoped self-hosted runners with these labels:
+
+- `self-hosted`
+- `chris-testing`
+- `chris-testing-discord-blue`
+
+This follows the product-repo pattern used by repos such as Sell Your Outboard
+and VeriReel. Individual runners may also carry per-runner labels such as
+`chris-testing-discord-blue-1` and `chris-testing-discord-blue-2` for targeted
+maintenance.

--- a/README.md
+++ b/README.md
@@ -158,3 +158,9 @@ unit, and restarts the service. The container migration target is narrower:
 
 Until Launchplane owns the deploy driver, the existing SSH/systemd workflow
 remains the production deployment path.
+
+GitHub Actions expects a repository variable named `DISCORD_BLUE_RUNNER_LABEL`
+that points at the self-hosted runner label authorized for this repo. Other
+operational repos use repo-specific labels such as `chris-testing-launchplane`,
+`chris-testing-verireel`, or `chris-testing-sellyouroutboard`; Discord Blue
+should follow that pattern before the container workflow is treated as mergeable.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ uv run python -m unittest discover -s tests -q
 
 A `Dockerfile` is provided to build a containerized version of the bot. It
 uses the [`ghcr.io/astral-sh/uv:debian`](https://github.com/astral-sh/uv) base
-image so `uv` is already available for dependency installation.
+image so `uv` is already available for dependency installation. The container
+starts through a small entrypoint that aligns the non-root `discord-blue` user
+with the mounted `/var/lib/discord-blue` owner, then runs the bot from that home
+directory. That keeps the container compatible with the existing LXC/systemd
+state directory during migration.
 
 Build the image:
 
@@ -115,15 +119,42 @@ Build the image:
 docker build -t discord-blue .
 ```
 
-Run the bot:
+Run the bot with the existing service state mounted:
 
 ```bash
-docker run --rm discord-blue
+docker run --rm \
+  --volume /var/lib/discord-blue:/var/lib/discord-blue \
+  --publish 127.0.0.1:8787:8787 \
+  discord-blue
 ```
 
-Or use Docker Compose, which mounts `${HOME}/.config/discord-blue` into the
-container for the generated config:
+Or use Docker Compose for a local smoke run:
 
 ```bash
 docker compose up -d
 ```
+
+Compose creates a `discord-blue-state` volume mounted at
+`/var/lib/discord-blue`. For the production LXC, Dokploy/Launchplane should bind
+the real `/var/lib/discord-blue` directory instead so
+`.config/discord-blue/config.toml` and `.code` Every Code state survive image
+replacement.
+
+The Every Code bridge listens on the configured `[every_code]` host and port.
+The image exposes port `8787`, and the local Compose file binds it to
+`127.0.0.1:8787`.
+
+## Launchplane/Dokploy migration target
+
+The current production workflow still SSHes into the LXC, runs `git pull`,
+rebuilds the uv environment under `/opt/discord-blue`, installs the systemd
+unit, and restarts the service. The container migration target is narrower:
+
+- CI proves the Docker image builds for every PR and push.
+- The production LXC keeps `/var/lib/discord-blue` as the durable state mount.
+- Dokploy pulls a versioned image and replaces the container.
+- Launchplane owns the deploy record, Dokploy mutation, and rollback decision.
+- This repo keeps source, image build inputs, tests, and smoke-check guidance.
+
+Until Launchplane owns the deploy driver, the existing SSH/systemd workflow
+remains the production deployment path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     build:
       context: .
     container_name: discord-blue
+    image: discord-blue:local
     volumes:
-      - "${HOME}/.config/discord-blue:/root/.config/discord-blue"
+      - "discord-blue-state:/var/lib/discord-blue"
+    ports:
+      - "127.0.0.1:8787:8787"
     restart: unless-stopped
+
+volumes:
+  discord-blue-state:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+state_dir=/var/lib/discord-blue
+runtime_user=discord-blue
+
+if [ -d "$state_dir" ]; then
+  state_uid=$(stat -c '%u' "$state_dir")
+  state_gid=$(stat -c '%g' "$state_dir")
+
+  if [ "$state_uid" = "0" ] && [ "$state_gid" = "0" ]; then
+    chown "$runtime_user:$runtime_user" "$state_dir"
+  else
+    if ! getent group "$state_gid" >/dev/null; then
+      groupmod --gid "$state_gid" "$runtime_user"
+    fi
+    runtime_group=$(getent group "$state_gid" | cut -d: -f1)
+    usermod --uid "$state_uid" --gid "$runtime_group" --home "$state_dir" "$runtime_user"
+  fi
+fi
+
+install -d -m 700 -o "$runtime_user" -g "$runtime_user" \
+  "$state_dir/.config/discord-blue"
+
+exec runuser --user "$runtime_user" -- "$@"


### PR DESCRIPTION
## Summary
- harden the Docker image as the production artifact candidate: non-root runtime, `/var/lib/discord-blue` state volume, Every Code bridge port exposure, installed script startup
- add an entrypoint that keeps fresh Docker volumes usable and aligns the container user with an existing LXC bind-mounted state directory
- update Compose/docs for the existing LXC/Dokploy migration target and publish GHCR images on non-PR builds
- add CI image build proof after Python validation

Refs #38

## Validation
- `actionlint .github/workflows/main.yml`
- `sh -n docker/entrypoint.sh`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run python -m unittest discover -s tests -q`
- `docker build -t discord-blue:launchplane-dokploy-lxc .`
- `docker run --rm --volume <tmp>:/var/lib/discord-blue --entrypoint /usr/local/bin/discord-blue-entrypoint discord-blue:launchplane-dokploy-lxc sh -lc 'id && test "$HOME" = /var/lib/discord-blue && test -d /var/lib/discord-blue/.config/discord-blue && test -x /app/.venv/bin/discord-blue && stat -c "%u:%g %a" /var/lib/discord-blue /var/lib/discord-blue/.config/discord-blue'`

## Notes
This keeps the existing SSH/systemd production deployment in place until Launchplane owns the Dokploy/LXC deploy driver.


## Runner validation
Discord Blue now has two repo-scoped self-hosted runners on the chris-testing host. The workflow uses concrete labels self-hosted, chris-testing, and chris-testing-discord-blue, matching the product-repo pattern. Manual branch validation on run 25332496122 passed on the new lane: validate and image succeeded; deploy skipped because the branch is not main.

