### PR TITLE
Gate legacy Discord Blue deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,10 @@ jobs:
 
   deploy:
     needs: image
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      vars.DISCORD_BLUE_LEGACY_DEPLOY_ENABLED == 'true'
     runs-on:
       - self-hosted
       - chris-testing

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ unit, and restarts the service. The container migration target is narrower:
 Until Launchplane owns the deploy driver, the existing SSH/systemd workflow
 remains the production deployment path.
 
+The legacy SSH/systemd deploy job is guarded by the repository variable
+`DISCORD_BLUE_LEGACY_DEPLOY_ENABLED`. Set it to `true` only when intentionally
+running that old path. Otherwise `main` pushes validate and publish the image
+without mutating the LXC.
+
 GitHub Actions expects repo-scoped self-hosted runners with these labels:
 
 - `self-hosted`


### PR DESCRIPTION
## Summary
- gate the legacy SSH/systemd deploy job behind `DISCORD_BLUE_LEGACY_DEPLOY_ENABLED == 'true'`
- document that main pushes publish the image without mutating the LXC unless the old path is explicitly enabled

Refs #38

## Validation
- `actionlint .github/workflows/main.yml`
- `sh -n docker/entrypoint.sh`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run python -m unittest discover -s tests -q`

## Context
PR #44 successfully published the container image, but the old deploy job failed on the new self-hosted runner because the Tailscale action needs passwordless sudo. Since that SSH/systemd path is legacy and should be replaced by Launchplane/Dokploy, this prevents future image publishes from going red unless we explicitly opt back into the old deploy path.
