### PR TITLE
Request Launchplane deploy after image publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ name: Deploy to Production
       - main
 permissions:
   contents: read
+  id-token: write
   packages: write
 jobs:
   validate:
@@ -38,6 +39,8 @@ jobs:
 
   image:
     needs: validate
+    outputs:
+      image_reference: ${{ steps.push.outputs.image_reference }}
     runs-on:
       - self-hosted
       - chris-testing
@@ -65,14 +68,93 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push container image
+        id: push
         if: github.event_name != 'pull_request'
         run: |
+          set -euo pipefail
           docker push ${{ steps.image.outputs.tag_sha }}
+          digest="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.image.outputs.tag_sha }})"
+          echo "image_reference=$digest" >> "$GITHUB_OUTPUT"
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             docker tag ${{ steps.image.outputs.tag_sha }} ${{ steps.image.outputs.tag_main }}
             docker push ${{ steps.image.outputs.tag_main }}
           fi
         shell: bash
+
+  launchplane-deploy:
+    needs: image
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+    runs-on:
+      - self-hosted
+      - chris-testing
+      - chris-testing-discord-blue
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_URL }}
+      LAUNCHPLANE_AUDIENCE: ${{ vars.LAUNCHPLANE_AUDIENCE }}
+    steps:
+      - name: Request Launchplane deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_URL variable}"
+          : "${{ needs.image.outputs.image_reference }}"
+
+          audience="${LAUNCHPLANE_AUDIENCE:-}"
+          if [ -z "$audience" ]; then
+            audience="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"])
+          if not parsed.hostname:
+              raise SystemExit("Could not derive Launchplane audience from LAUNCHPLANE_URL.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}" \
+            | jq -r '.value'
+          })"
+
+          request_payload="$({
+            jq -n \
+              --arg image_reference "${{ needs.image.outputs.image_reference }}" \
+              --arg source_git_ref "$GITHUB_SHA" \
+              '{
+                schema_version: 1,
+                product: "discord-blue",
+                deploy: {
+                  schema_version: 1,
+                  product: "discord-blue",
+                  instance: "prod",
+                  artifact_id: $image_reference,
+                  source_git_ref: $source_git_ref
+                }
+              }'
+          })"
+
+          response_file="$(mktemp)"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            -H "Idempotency-Key: discord-blue-stable-deploy:${GITHUB_SHA}" \
+            --data "$request_payload" \
+            "${LAUNCHPLANE_URL%/}/v1/drivers/generic-web/deploy")"
+          cat "$response_file"
+          if [ "$status_code" != "200" ] && [ "$status_code" != "202" ]; then
+            echo "Launchplane deploy request failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
 
   deploy:
     needs: image


### PR DESCRIPTION
## Summary
- publish the image digest as the image job output
- request Launchplane generic-web deploy for discord-blue/prod after main image publish
- keep the legacy SSH/systemd deploy behind DISCORD_BLUE_LEGACY_DEPLOY_ENABLED

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q
- actionlint .github/workflows/main.yml
- git diff --check

## Ordering
Requires cbusillo/launchplane#251 to land first so Launchplane exposes /v1/product-onboarding/apply and seeds the Discord Blue deploy grant.

Refs #38
Blocked by cbusillo/launchplane#251