### PR TITLE
Fail workflow when Launchplane deploy records failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,12 @@ jobs:
             echo "Launchplane deploy request failed with HTTP ${status_code}." >&2
             exit 1
           fi
+          deploy_status="$(jq -r '.result.deploy_status // empty' "$response_file")"
+          if [ "$deploy_status" != "pass" ]; then
+            error_message="$(jq -r '.result.error_message // "Launchplane deploy did not pass."' "$response_file")"
+            echo "$error_message" >&2
+            exit 1
+          fi
 
   deploy:
     needs: image


### PR DESCRIPTION
## Summary
- inspect Launchplane generic-web deploy result payload
- fail the GitHub Actions job when Launchplane records deploy_status other than pass
- surface Launchplane error_message in job logs

## Why
The first main run after #48 correctly recorded a Launchplane deploy failure for missing discord-blue/prod Dokploy target-id, but the workflow only checked HTTP 202. This makes the handoff fail closed.

## Validation
- actionlint .github/workflows/main.yml
- git diff --check

Refs #38