### PR TITLE
feat(every-code): mark automated sessions in DUI

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -37,6 +37,7 @@ from discord_blue.doodads.every_code.threads import SessionThread
 from discord_blue.doodads.every_code.threads import auto_join_configured_users
 from discord_blue.doodads.every_code.threads import create_session_thread
 from discord_blue.doodads.every_code.threads import get_every_code_channel
+from discord_blue.doodads.every_code.threads import session_display_name
 from discord_blue.doodads.every_code.threads import session_start_message
 from discord_blue.plugs.discord_plug import BlueBot
 
@@ -894,7 +895,7 @@ class EveryCodeBridge:
 
         lines = ["Live Every Code sessions:"]
         for session in sessions:
-            repo = Path(session.hello.cwd).name or "session"
+            repo = session_display_name(session.hello)
             branch = f" on `{session.hello.branch}`" if session.hello.branch else ""
             thread = f" <#{session.thread_id}>" if session.thread_id is not None else ""
             state = "offline" if session.websocket.closed else "online"
@@ -915,7 +916,7 @@ class EveryCodeBridge:
         if session is None:
             return "This thread is not attached to a live Every Code session."
 
-        repo = Path(session.hello.cwd).name or "session"
+        repo = session_display_name(session.hello)
         branch = f" on `{session.hello.branch}`" if session.hello.branch else ""
         state = "offline" if session.websocket.closed else "online"
         status = session.last_status_message or "No status update received yet."

--- a/discord_blue/doodads/every_code/protocol.py
+++ b/discord_blue/doodads/every_code/protocol.py
@@ -5,6 +5,30 @@ from typing import Any, Literal
 
 
 @dataclass(slots=True)
+class SessionOrigin:
+    kind: str
+    request_id: str | None
+    repository: str | None
+    issue_number: int | None
+    issue_url: str | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "SessionOrigin":
+        issue_number = payload.get("issue_number")
+        try:
+            parsed_issue_number = int(issue_number) if issue_number is not None else None
+        except (TypeError, ValueError):
+            parsed_issue_number = None
+        return cls(
+            kind=str(payload.get("kind") or ""),
+            request_id=str(payload["request_id"]) if payload.get("request_id") else None,
+            repository=str(payload["repository"]) if payload.get("repository") else None,
+            issue_number=parsed_issue_number,
+            issue_url=str(payload["issue_url"]) if payload.get("issue_url") else None,
+        )
+
+
+@dataclass(slots=True)
 class SessionHello:
     session_id: str
     session_epoch: str
@@ -12,9 +36,12 @@ class SessionHello:
     cwd: str
     branch: str | None
     pid: int
+    origin: SessionOrigin | None = None
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any]) -> "SessionHello":
+        origin_payload = payload.get("origin")
+        origin = SessionOrigin.from_payload(origin_payload) if isinstance(origin_payload, dict) else None
         return cls(
             session_id=str(payload["session_id"]),
             session_epoch=str(payload["session_epoch"]),
@@ -22,6 +49,7 @@ class SessionHello:
             cwd=str(payload.get("cwd") or ""),
             branch=str(payload["branch"]) if payload.get("branch") else None,
             pid=int(payload.get("pid") or 0),
+            origin=origin,
         )
 
 

--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -19,9 +19,32 @@ class SessionThread:
 
 
 def session_thread_name(hello: SessionHello) -> str:
-    repo = Path(hello.cwd).name or "session"
+    repo = session_display_name(hello)
     branch = f" · {hello.branch}" if hello.branch else ""
     return f"{repo}{branch}"
+
+
+def session_display_name(hello: SessionHello) -> str:
+    repo = Path(hello.cwd).name or "session"
+    if hello.origin and hello.origin.kind == "every_code" and hello.origin.repository:
+        repo = hello.origin.repository.rsplit("/", 1)[-1]
+        issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
+        return f"EC {repo}{issue}"
+    return repo
+
+
+def session_origin_lines(hello: SessionHello) -> list[str]:
+    if not hello.origin or hello.origin.kind != "every_code":
+        return []
+    lines = ["origin: `Every Code automation`"]
+    if hello.origin.repository:
+        issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
+        lines.append(f"source: `{hello.origin.repository}{issue}`")
+    if hello.origin.issue_url:
+        lines.append(f"issue: {hello.origin.issue_url}")
+    if hello.origin.request_id:
+        lines.append(f"request: `{hello.origin.request_id}`")
+    return lines
 
 
 def session_start_message(hello: SessionHello) -> str:
@@ -30,6 +53,7 @@ def session_start_message(hello: SessionHello) -> str:
         [
             "Every Code session connected",
             "",
+            *session_origin_lines(hello),
             f"host: {hello.host_label}",
             f"cwd: `{hello.cwd}`",
             f"branch: `{branch}`",
@@ -40,8 +64,13 @@ def session_start_message(hello: SessionHello) -> str:
 
 def session_notification_message(hello: SessionHello, thread: discord.Thread) -> str:
     repo = Path(hello.cwd).name or "session"
+    prefix = "Every Code session connected"
+    if hello.origin and hello.origin.kind == "every_code" and hello.origin.repository:
+        issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
+        repo = f"{hello.origin.repository}{issue}"
+        prefix = "Every Code automated session connected"
     branch = f" on `{hello.branch}`" if hello.branch else ""
-    return f"Every Code session connected for `{repo}`{branch}: <#{thread.id}>"
+    return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
 
 
 async def get_every_code_channel(bot: BlueBot) -> discord.TextChannel:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -65,6 +65,7 @@ RemoteRequestUserInput = protocol_module.RemoteRequestUserInput
 RequestUserInputQuestion = protocol_module.RequestUserInputQuestion
 RequestUserInputQuestionOption = protocol_module.RequestUserInputQuestionOption
 SessionHello = protocol_module.SessionHello
+SessionOrigin = protocol_module.SessionOrigin
 SessionStatus = protocol_module.SessionStatus
 sessions_module = importlib.import_module("discord_blue.doodads.every_code.sessions")
 EveryCodeSession = sessions_module.EveryCodeSession
@@ -172,6 +173,29 @@ class ProtocolTests(unittest.TestCase):
         self.assertEqual(hello.cwd, "/tmp/project")
         self.assertIsNone(hello.branch)
         self.assertEqual(hello.pid, 0)
+        self.assertIsNone(hello.origin)
+
+    def test_session_hello_from_payload_parses_origin(self) -> None:
+        hello = SessionHello.from_payload(
+            {
+                "session_id": "session-1",
+                "session_epoch": "epoch-1",
+                "cwd": "/tmp/project",
+                "origin": {
+                    "kind": "every_code",
+                    "request_id": "every-code-cbusillo-syo-67",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "issue_number": 67,
+                    "issue_url": "https://github.com/cbusillo/sellyouroutboard/issues/67",
+                },
+            }
+        )
+
+        self.assertIsNotNone(hello.origin)
+        assert hello.origin is not None
+        self.assertEqual(hello.origin.kind, "every_code")
+        self.assertEqual(hello.origin.repository, "cbusillo/sellyouroutboard")
+        self.assertEqual(hello.origin.issue_number, 67)
 
     def test_remote_command_serializes_bridge_message(self) -> None:
         command = RemoteCommand(
@@ -315,6 +339,38 @@ class ThreadFormattingTests(unittest.TestCase):
             "Every Code session connected for `session`: <#555>",
         )
         self.assertIn("branch: `unknown`", session_start_message(hello))
+
+    def test_session_thread_text_marks_every_code_origin(self) -> None:
+        hello = SessionHello(
+            session_id="session-1",
+            session_epoch="epoch-1",
+            host_label="Mac Studio",
+            cwd="/tmp/worktree",
+            branch="every-code/cbusillo-syo-67",
+            pid=42,
+            origin=SessionOrigin(
+                kind="every_code",
+                request_id="every-code-cbusillo-syo-67",
+                repository="cbusillo/sellyouroutboard",
+                issue_number=67,
+                issue_url="https://github.com/cbusillo/sellyouroutboard/issues/67",
+            ),
+        )
+        thread = SimpleNamespace(id=555)
+
+        self.assertEqual(
+            session_thread_name(hello),
+            "EC sellyouroutboard#67 · every-code/cbusillo-syo-67",
+        )
+        self.assertEqual(
+            session_notification_message(hello, thread),
+            "Every Code automated session connected for `cbusillo/sellyouroutboard#67` on `every-code/cbusillo-syo-67`: <#555>",
+        )
+        start_message = session_start_message(hello)
+        self.assertIn("origin: `Every Code automation`", start_message)
+        self.assertIn("source: `cbusillo/sellyouroutboard#67`", start_message)
+        self.assertIn("issue: https://github.com/cbusillo/sellyouroutboard/issues/67", start_message)
+        self.assertIn("request: `every-code-cbusillo-syo-67`", start_message)
 
 
 class FakeThreadTests(unittest.IsolatedAsyncioTestCase):
@@ -1689,6 +1745,42 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(bridge.active_sessions_summary(), "No live Every Code sessions.")
 
+    async def test_active_sessions_summary_marks_every_code_origin(self) -> None:
+        config = Config()
+        bridge = EveryCodeBridge(FakeBot(config))
+        hello = SessionHello(
+            session_id="session-1",
+            session_epoch="epoch-1",
+            host_label="Mac Studio",
+            cwd="/tmp/project",
+            branch="main",
+            pid=42,
+            origin=SessionOrigin(
+                kind="every_code",
+                request_id="every-code-cbusillo-syo-67",
+                repository="cbusillo/sellyouroutboard",
+                issue_number=67,
+                issue_url="https://github.com/cbusillo/sellyouroutboard/issues/67",
+            ),
+        )
+        session = EveryCodeSession(
+            hello=hello,
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        self.assertEqual(
+            bridge.active_sessions_summary(),
+            "\n".join(
+                [
+                    "Live Every Code sessions:",
+                    "- `EC sellyouroutboard#67` on `main` (online, Mac Studio) <#555>",
+                ]
+            ),
+        )
+
     async def test_session_status_summary_uses_last_status(self) -> None:
         config = Config()
         config.discord.employee_role_name = ""
@@ -1720,6 +1812,46 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
                     "state: online",
                     "host: Mac Studio",
                     "status: Turn started",
+                ]
+            ),
+        )
+
+    async def test_session_status_summary_marks_every_code_origin(self) -> None:
+        config = Config()
+        config.discord.employee_role_name = ""
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        hello = SessionHello(
+            session_id="session-1",
+            session_epoch="epoch-1",
+            host_label="Mac Studio",
+            cwd="/tmp/project",
+            branch="main",
+            pid=42,
+            origin=SessionOrigin(
+                kind="every_code",
+                request_id="every-code-cbusillo-syo-67",
+                repository="cbusillo/sellyouroutboard",
+                issue_number=67,
+                issue_url="https://github.com/cbusillo/sellyouroutboard/issues/67",
+            ),
+        )
+        session = EveryCodeSession(
+            hello=hello,
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        self.assertEqual(
+            bridge.session_status_summary(thread, SimpleNamespace(id=123)),
+            "\n".join(
+                [
+                    "Every Code `EC sellyouroutboard#67` on `main`",
+                    "state: online",
+                    "host: Mac Studio",
+                    "status: No status update received yet.",
                 ]
             ),
         )


### PR DESCRIPTION
## Summary
- parse structured Every Code session origin metadata from Code hello payloads
- mark automated sessions as `EC <repo>#<issue>` in thread names, notifications, `/code sessions`, and `/code status`
- include issue/request origin details in the session start message

Refs cbusillo/discord-blue#54.

## Validation
- uv run python -m unittest tests.test_every_code
- uv run mypy discord_blue tests