### PR TITLE
fix(every-code): keep automated thread names short

### DIFF
--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -10,6 +10,7 @@ from discord_blue.doodads.every_code.protocol import SessionHello
 from discord_blue.plugs.discord_plug import BlueBot
 
 logger = logging.getLogger(__name__)
+DISCORD_THREAD_NAME_LIMIT = 100
 
 
 @dataclass(slots=True)
@@ -20,8 +21,10 @@ class SessionThread:
 
 def session_thread_name(hello: SessionHello) -> str:
     repo = session_display_name(hello)
+    if hello.origin and hello.origin.kind == "every_code":
+        return _truncate_thread_name(repo)
     branch = f" · {hello.branch}" if hello.branch else ""
-    return f"{repo}{branch}"
+    return _truncate_thread_name(f"{repo}{branch}")
 
 
 def session_display_name(hello: SessionHello) -> str:
@@ -31,6 +34,12 @@ def session_display_name(hello: SessionHello) -> str:
         issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
         return f"EC {repo}{issue}"
     return repo
+
+
+def _truncate_thread_name(name: str) -> str:
+    if len(name) <= DISCORD_THREAD_NAME_LIMIT:
+        return name
+    return name[: DISCORD_THREAD_NAME_LIMIT - 1].rstrip() + "…"
 
 
 def session_origin_lines(hello: SessionHello) -> list[str]:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -360,7 +360,7 @@ class ThreadFormattingTests(unittest.TestCase):
 
         self.assertEqual(
             session_thread_name(hello),
-            "EC sellyouroutboard#67 · every-code/cbusillo-syo-67",
+            "EC sellyouroutboard#67",
         )
         self.assertEqual(
             session_notification_message(hello, thread),
@@ -371,6 +371,21 @@ class ThreadFormattingTests(unittest.TestCase):
         self.assertIn("source: `cbusillo/sellyouroutboard#67`", start_message)
         self.assertIn("issue: https://github.com/cbusillo/sellyouroutboard/issues/67", start_message)
         self.assertIn("request: `every-code-cbusillo-syo-67`", start_message)
+
+    def test_session_thread_name_caps_human_branch_length(self) -> None:
+        hello = SessionHello(
+            session_id="session-1",
+            session_epoch="epoch-1",
+            host_label="Mac Studio",
+            cwd="/tmp/project",
+            branch="feature/" + "x" * 160,
+            pid=42,
+        )
+
+        thread_name = session_thread_name(hello)
+
+        self.assertLessEqual(len(thread_name), 100)
+        self.assertTrue(thread_name.endswith("…"))
 
 
 class FakeThreadTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- use compact `EC <repo>#<issue>` thread names for automated Every Code sessions
- defensively cap all generated thread names to Discord's 100-character limit
- keep branch/source/request details in the thread notification/start message instead of the thread title

Fixes the live SYO #81 smoke path where the session connected to Discord Blue but no DUI thread appeared.

## Validation
- uv run python -m unittest tests.test_every_code.ThreadFormattingTests tests.test_every_code.BridgeTests.test_active_sessions_summary_marks_every_code_origin tests.test_every_code.BridgeTests.test_session_status_summary_marks_every_code_origin
- uv run mypy discord_blue tests
- uv run python -m unittest tests.test_every_code