### PR TITLE
Suppress Every Code Discord link previews

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -15,6 +15,9 @@ from typing import Literal, cast
 import discord
 from aiohttp import WSMsgType, web
 
+from discord_blue.doodads.every_code.messages import edit_every_code_message
+from discord_blue.doodads.every_code.messages import every_code_allowed_mentions
+from discord_blue.doodads.every_code.messages import send_every_code_message
 from discord_blue.doodads.every_code.protocol import (
     RequestUserInputQuestion,
     RemoteApprovalDecision,
@@ -123,7 +126,8 @@ class RequestUserInputSelect(discord.ui.Select[discord.ui.View]):
         await interaction.response.edit_message(
             content=self.parent_view.format_prompt(),
             view=self.parent_view,
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=every_code_allowed_mentions(),
+            suppress_embeds=True,
         )
 
 
@@ -153,7 +157,8 @@ class RequestUserInputAnswerModal(discord.ui.Modal):
         await interaction.response.edit_message(
             content=self.parent_view.format_prompt(),
             view=self.parent_view,
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=every_code_allowed_mentions(),
+            suppress_embeds=True,
         )
 
 
@@ -608,9 +613,9 @@ class EveryCodeBridge:
         if assistant_message is None:
             return
         for message in self.format_assistant_messages(assistant_message):
-            await thread.send(
+            await send_every_code_message(
+                thread,
                 message[:DISCORD_MESSAGE_LIMIT],
-                allowed_mentions=discord.AllowedMentions.none(),
             )
 
     @staticmethod
@@ -1002,9 +1007,9 @@ class EveryCodeBridge:
         if not isinstance(channel, discord.Thread):
             return
 
-        message = await channel.send(
+        message = await send_every_code_message(
+            channel,
             self.format_approval_request(approval),
-            allowed_mentions=discord.AllowedMentions.none(),
         )
         await self.add_message_reactions(
             message,
@@ -1036,9 +1041,9 @@ class EveryCodeBridge:
         if not isinstance(channel, discord.Thread):
             return
 
-        message = await channel.send(
+        message = await send_every_code_message(
+            channel,
             self.format_request_user_input(request, {}),
-            allowed_mentions=discord.AllowedMentions.none(),
             view=self.request_user_input_view(session.session_id, request),
         )
         session.pending_user_inputs[request.turn_id] = PendingRemoteUserInput(
@@ -1101,7 +1106,8 @@ class EveryCodeBridge:
         await interaction.response.edit_message(
             content=self.format_request_user_input_pending(interaction.user, cancelled=cancelled),
             view=None,
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=every_code_allowed_mentions(),
+            suppress_embeds=True,
         )
 
     async def handle_approval_interaction(
@@ -1147,7 +1153,8 @@ class EveryCodeBridge:
         await interaction.response.edit_message(
             content=self.format_approval_pending(decision, interaction.user),
             view=None,
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=every_code_allowed_mentions(),
+            suppress_embeds=True,
         )
 
     async def handle_thread_reaction(
@@ -1362,10 +1369,9 @@ class EveryCodeBridge:
             return
         try:
             message = await channel.fetch_message(pending.message_id)
-            await message.edit(
+            await edit_every_code_message(
+                message,
                 content=content[:DISCORD_MESSAGE_LIMIT],
-                view=None,
-                allowed_mentions=discord.AllowedMentions.none(),
             )
             await self.clear_message_reactions(message)
         except discord.DiscordException:
@@ -1437,9 +1443,9 @@ class EveryCodeBridge:
         if not isinstance(channel, discord.Thread):
             return
 
-        await channel.send(
+        await send_every_code_message(
+            channel,
             self.format_user_message_notice(user_message.message)[:DISCORD_MESSAGE_LIMIT],
-            allowed_mentions=discord.AllowedMentions.none(),
         )
         await self.spawn_session_controls(
             session,
@@ -1518,9 +1524,9 @@ class EveryCodeBridge:
             await self.refresh_session_controls(session, thread)
             if session.control_message_id is not None:
                 return
-        message = await thread.send(
+        message = await send_every_code_message(
+            thread,
             self.format_waiting_for_direction(session),
-            allowed_mentions=discord.AllowedMentions.none(),
         )
         await self.add_message_reactions(message, self.session_control_reactions(session))
         session.control_message_id = message.id
@@ -1589,9 +1595,9 @@ class EveryCodeBridge:
                 return
             session.control_message_id = None
 
-        message = await channel.send(
+        message = await send_every_code_message(
+            channel,
             self.format_waiting_for_direction(session),
-            allowed_mentions=discord.AllowedMentions.none(),
         )
         await self.add_message_reactions(
             message,
@@ -1615,10 +1621,9 @@ class EveryCodeBridge:
                 continue
             try:
                 message = await channel.fetch_message(pending.message_id)
-                await message.edit(
+                await edit_every_code_message(
+                    message,
                     content=content[:DISCORD_MESSAGE_LIMIT],
-                    view=None,
-                    allowed_mentions=discord.AllowedMentions.none(),
                 )
             except discord.DiscordException:
                 logger.warning(
@@ -1684,9 +1689,9 @@ class EveryCodeBridge:
         session.control_interruptions_enabled = interruptions_enabled
 
         try:
-            message = await channel.send(
+            message = await send_every_code_message(
+                channel,
                 self.format_waiting_for_direction(session),
-                allowed_mentions=discord.AllowedMentions.none(),
             )
             await self.add_message_reactions(message, self.session_control_reactions(session))
         except discord.DiscordException:
@@ -1714,9 +1719,9 @@ class EveryCodeBridge:
     async def post_thread_notice(self, thread_id: int, text: str) -> None:
         channel = self.bot.get_channel(thread_id)
         if isinstance(channel, discord.Thread):
-            await channel.send(
+            await send_every_code_message(
+                channel,
                 text[:DISCORD_MESSAGE_LIMIT],
-                allowed_mentions=discord.AllowedMentions.none(),
             )
 
     async def close_session_thread(self, session: EveryCodeSession) -> None:
@@ -1744,9 +1749,9 @@ class EveryCodeBridge:
                 logger.warning("Unable to unarchive Every Code thread %s", thread.id)
 
         try:
-            await thread.send(
+            await send_every_code_message(
+                thread,
                 "Every Code session disconnected",
-                allowed_mentions=discord.AllowedMentions.none(),
             )
         except discord.DiscordException:
             logger.warning("Unable to post close notice in Every Code thread %s", thread.id)
@@ -1945,9 +1950,9 @@ class EveryCodeBridge:
         if replaced:
             return
         session.control_message_id = None
-        message = await thread.send(
+        message = await send_every_code_message(
+            thread,
             self.format_waiting_for_direction(session),
-            allowed_mentions=discord.AllowedMentions.none(),
         )
         await self.add_message_reactions(message, self.session_control_reactions(session))
         session.control_message_id = message.id

--- a/discord_blue/doodads/every_code/messages.py
+++ b/discord_blue/doodads/every_code/messages.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import discord
+
+
+def every_code_allowed_mentions() -> discord.AllowedMentions:
+    return discord.AllowedMentions.none()
+
+
+async def send_every_code_message(
+    destination: discord.abc.Messageable,
+    content: str | None = None,
+    *,
+    view: discord.ui.View | None = None,
+) -> discord.Message:
+    if view is None:
+        return await destination.send(
+            content,
+            allowed_mentions=every_code_allowed_mentions(),
+            suppress_embeds=True,
+        )
+
+    return await destination.send(
+        content,
+        allowed_mentions=every_code_allowed_mentions(),
+        suppress_embeds=True,
+        view=view,
+    )
+
+
+async def edit_every_code_message(message: discord.Message, *, content: str) -> discord.Message:
+    return await message.edit(content=content, allowed_mentions=every_code_allowed_mentions(), suppress=True, view=None)

--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import discord
 
+from discord_blue.doodads.every_code.messages import send_every_code_message
 from discord_blue.doodads.every_code.protocol import SessionHello
 from discord_blue.plugs.discord_plug import BlueBot
 
@@ -87,11 +88,8 @@ async def create_session_thread(bot: BlueBot, hello: SessionHello) -> SessionThr
         name=session_thread_name(hello),
         auto_archive_duration=1440,
     )
-    notification = await channel.send(
-        session_notification_message(hello, thread),
-        allowed_mentions=discord.AllowedMentions.none(),
-    )
-    await thread.send(session_start_message(hello))
+    notification = await send_every_code_message(channel, session_notification_message(hello, thread))
+    await send_every_code_message(thread, session_start_message(hello))
     await auto_join_configured_users(bot, thread)
     return SessionThread(thread=thread, notification_message_id=notification.id)
 

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -44,6 +44,7 @@ class FakeReplyMessage:
         self.replies: list[str] = []
         self.reply_mentions: list[bool] = []
         self.edits: list[tuple[str, bool]] = []
+        self.edit_kwargs: list[dict[str, object]] = []
         self.deleted = False
         self.delete_raises = False
 
@@ -64,6 +65,7 @@ class FakeReplyMessage:
     async def edit(self, content: str, **kwargs: object) -> None:
         self.content = content
         self.edits.append((content, kwargs.get("view") is None))
+        self.edit_kwargs.append(kwargs)
 
     async def delete(self) -> None:
         if self.delete_raises:
@@ -84,6 +86,7 @@ class FakeThread:
         self._history: list[FakeReplyMessage] = []
         self.sent_messages: list[str] = []
         self.sent_views: list[object] = []
+        self.sent_kwargs: list[dict[str, object]] = []
         self.edits: list[dict[str, object]] = []
 
     def add_message(self, message: FakeReplyMessage) -> None:
@@ -119,6 +122,7 @@ class FakeThread:
         stored_content = content or ""
         self.sent_messages.append(stored_content)
         self.sent_views.append(kwargs.get("view"))
+        self.sent_kwargs.append(kwargs)
         message = FakeReplyMessage(
             900 + len(self.sent_messages),
             self,
@@ -141,10 +145,23 @@ class FakeTextChannel:
         self.id = channel_id
         self.threads = [thread for thread in threads if not thread.archived]
         self._archived_threads = [thread for thread in threads if thread.archived]
+        self.sent_messages: list[str] = []
+        self.sent_kwargs: list[dict[str, object]] = []
 
     async def archived_threads(self, **_: object) -> AsyncIterator[FakeThread]:
         for thread in self._archived_threads:
             yield thread
+
+    async def create_thread(self, **kwargs: object) -> FakeThread:
+        thread = FakeThread(9000 + len(self.threads))
+        self.threads.append(thread)
+        return thread
+
+    async def send(self, content: str | None = None, **kwargs: object) -> FakeReplyMessage:
+        stored_content = content or ""
+        self.sent_messages.append(stored_content)
+        self.sent_kwargs.append(kwargs)
+        return FakeReplyMessage(800 + len(self.sent_messages), FakeThread(self.id), stored_content)
 
 
 class FakeInteractionResponse:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -71,6 +71,7 @@ sessions_module = importlib.import_module("discord_blue.doodads.every_code.sessi
 EveryCodeSession = sessions_module.EveryCodeSession
 EveryCodeSessionRegistry = sessions_module.EveryCodeSessionRegistry
 threads_module = importlib.import_module("discord_blue.doodads.every_code.threads")
+create_session_thread = threads_module.create_session_thread
 session_notification_message = threads_module.session_notification_message
 session_start_message = threads_module.session_start_message
 session_thread_name = threads_module.session_thread_name
@@ -298,7 +299,24 @@ class ProtocolTests(unittest.TestCase):
         )
 
 
-class ThreadFormattingTests(unittest.TestCase):
+class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.original_text_channel_type = threads_module.discord.TextChannel
+        threads_module.discord.TextChannel = FakeTextChannel
+
+    async def asyncTearDown(self) -> None:
+        threads_module.discord.TextChannel = self.original_text_channel_type
+
+    async def test_create_session_thread_suppresses_embeds_on_start_messages(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+
+        session_thread = await create_session_thread(FakeBot(config, channel=channel), make_hello())
+
+        self.assertTrue(channel.sent_kwargs[0]["suppress_embeds"])
+        self.assertTrue(session_thread.thread.sent_kwargs[0]["suppress_embeds"])
+
     def test_session_thread_text_uses_repo_branch_and_no_mentions(self) -> None:
         hello = make_hello()
         thread = SimpleNamespace(id=555)
@@ -848,6 +866,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(thread.sent_messages), 1)
         self.assertIn("Need approval", thread.sent_messages[0])
         self.assertIn("Quick review", thread.sent_messages[0])
+        self.assertTrue(thread.sent_kwargs[0]["suppress_embeds"])
         self.assertIsNone(thread.sent_views[0])
         approval_message = await thread.fetch_message(901)
         self.assertEqual(approval_message.reactions, ["✅", "✖️"])
@@ -1302,6 +1321,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         approval_message = await thread.fetch_message(901)
         self.assertIn("Approval sent", approval_message.content)
         self.assertEqual(approval_message.reactions, [])
+        self.assertTrue(approval_message.edit_kwargs[-1]["suppress"])
         self.assertEqual(websocket.sent_json[0]["decision"], "approved")
 
     async def test_approval_decision_ack_marks_message_finished(self) -> None:
@@ -1937,6 +1957,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         await bridge.backfill_latest_assistant_message(thread, make_hello())
 
         self.assertEqual(thread.sent_messages, ["**Assistant**\nRecovered answer"])
+        self.assertTrue(thread.sent_kwargs[0]["suppress_embeds"])
 
     async def test_backfill_skips_thread_with_existing_assistant(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- add shared Every Code message helpers that disable allowed mentions and suppress link embeds
- route Every Code send/edit paths through the helpers
- extend fakes/tests to assert suppression on session start, assistant backfill, approvals, and edited approval state

## Validation
- uv run ruff format --check discord_blue/doodads/every_code/messages.py discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py
- uv run ruff check --diff discord_blue/doodads/every_code/messages.py discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/messages.py discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py
- uv run python -m unittest tests.test_every_code -q
- uv run mypy discord_blue/doodads/every_code tests/test_every_code.py tests/fakes_every_code.py