### PR TITLE
Avoid suppress flag on Every Code edits

### DIFF
--- a/discord_blue/doodads/every_code/messages.py
+++ b/discord_blue/doodads/every_code/messages.py
@@ -29,4 +29,4 @@ async def send_every_code_message(
 
 
 async def edit_every_code_message(message: discord.Message, *, content: str) -> discord.Message:
-    return await message.edit(content=content, allowed_mentions=every_code_allowed_mentions(), suppress=True, view=None)
+    return await message.edit(content=content, allowed_mentions=every_code_allowed_mentions(), view=None)

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -1336,7 +1336,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         approval_message = await thread.fetch_message(901)
         self.assertIn("Approval sent", approval_message.content)
         self.assertEqual(approval_message.reactions, [])
-        self.assertTrue(approval_message.edit_kwargs[-1]["suppress"])
+        self.assertNotIn("suppress", approval_message.edit_kwargs[-1])
         self.assertEqual(websocket.sent_json[0]["decision"], "approved")
 
     async def test_approval_decision_ack_marks_message_finished(self) -> None:


### PR DESCRIPTION
## Summary
- remove the message edit suppress flag so approval and prompt-cleanup edits do not require Manage Messages
- keep send-time suppress_embeds behavior intact
- update tests to assert content-only approval edits do not pass suppress

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q