### PR TITLE
Avoid suppress flag on Every Code interaction edits

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -127,7 +127,6 @@ class RequestUserInputSelect(discord.ui.Select[discord.ui.View]):
             content=self.parent_view.format_prompt(),
             view=self.parent_view,
             allowed_mentions=every_code_allowed_mentions(),
-            suppress_embeds=True,
         )
 
 
@@ -158,7 +157,6 @@ class RequestUserInputAnswerModal(discord.ui.Modal):
             content=self.parent_view.format_prompt(),
             view=self.parent_view,
             allowed_mentions=every_code_allowed_mentions(),
-            suppress_embeds=True,
         )
 
 
@@ -1107,7 +1105,6 @@ class EveryCodeBridge:
             content=self.format_request_user_input_pending(interaction.user, cancelled=cancelled),
             view=None,
             allowed_mentions=every_code_allowed_mentions(),
-            suppress_embeds=True,
         )
 
     async def handle_approval_interaction(
@@ -1154,7 +1151,6 @@ class EveryCodeBridge:
             content=self.format_approval_pending(decision, interaction.user),
             view=None,
             allowed_mentions=every_code_allowed_mentions(),
-            suppress_embeds=True,
         )
 
     async def handle_thread_reaction(

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -168,6 +168,7 @@ class FakeInteractionResponse:
     def __init__(self) -> None:
         self.messages: list[tuple[str, bool]] = []
         self.edits: list[tuple[str, bool]] = []
+        self.edit_kwargs: list[dict[str, object]] = []
         self.modals: list[object] = []
 
     async def send_message(self, content: str, *, ephemeral: bool) -> None:
@@ -175,6 +176,7 @@ class FakeInteractionResponse:
 
     async def edit_message(self, content: str, **kwargs: object) -> None:
         self.edits.append((content, kwargs.get("view") is None))
+        self.edit_kwargs.append(kwargs)
 
     async def send_modal(self, modal: object) -> None:
         self.modals.append(modal)

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -70,6 +70,7 @@ SessionStatus = protocol_module.SessionStatus
 sessions_module = importlib.import_module("discord_blue.doodads.every_code.sessions")
 EveryCodeSession = sessions_module.EveryCodeSession
 EveryCodeSessionRegistry = sessions_module.EveryCodeSessionRegistry
+PendingRemoteApproval = sessions_module.PendingRemoteApproval
 threads_module = importlib.import_module("discord_blue.doodads.every_code.threads")
 create_session_thread = threads_module.create_session_thread
 session_notification_message = threads_module.session_notification_message
@@ -1339,6 +1340,29 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("suppress", approval_message.edit_kwargs[-1])
         self.assertEqual(websocket.sent_json[0]["decision"], "approved")
 
+    async def test_approval_interaction_does_not_suppress_embeds_on_edit(self) -> None:
+        config = Config()
+        config.discord.employee_role_name = ""
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        websocket = FakeWebSocket()
+        session = EveryCodeSession(hello=make_hello(), websocket=websocket, thread_id=555)
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+        session.pending_approvals["approval-1"] = PendingRemoteApproval(thread_id=555, message_id=901)
+        interaction = FakeInteraction(thread)
+
+        await bridge.handle_approval_interaction(
+            cast(Any, interaction),
+            "session-1",
+            "approval-1",
+            "approved",
+        )
+
+        self.assertIn("Approval sent", interaction.response.edits[0][0])
+        self.assertNotIn("suppress_embeds", interaction.response.edit_kwargs[0])
+        self.assertEqual(websocket.sent_json[0]["decision"], "approved")
+
     async def test_approval_decision_ack_marks_message_finished(self) -> None:
         config = Config()
         thread = FakeThread(555)
@@ -1545,6 +1569,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             {"answers": {"mode": {"answers": ["Safe"]}}},
         )
         self.assertIn("Answer sent", interaction.response.edits[0][0])
+        self.assertNotIn("suppress_embeds", interaction.response.edit_kwargs[0])
 
     async def test_request_user_input_cancel_sends_empty_response(self) -> None:
         config = Config()
@@ -1591,6 +1616,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(websocket.sent_json[0]["turn_id"], "turn-1")
         self.assertEqual(websocket.sent_json[0]["response"], {"answers": {}})
         self.assertIn("Answer cancelled", interaction.response.edits[0][0])
+        self.assertNotIn("suppress_embeds", interaction.response.edit_kwargs[0])
 
     async def test_status_changed_preserves_contextual_controls_for_active_reply_command(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- remove suppress_embeds from Every Code interaction response edits so they do not require Manage Messages
- keep send-time embed suppression intact
- add tests covering request-user-input and approval interaction edits

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q