### PR TITLE
Fall back when Every Code preview suppression lacks permission

### DIFF
--- a/discord_blue/doodads/every_code/messages.py
+++ b/discord_blue/doodads/every_code/messages.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
+import logging
+
 import discord
+
+logger = logging.getLogger(__name__)
+MISSING_MANAGE_MESSAGES_DESTINATIONS: set[int] = set()
 
 
 def every_code_allowed_mentions() -> discord.AllowedMentions:
     return discord.AllowedMentions.none()
+
+
+def can_suppress_embeds(destination: discord.abc.Messageable) -> bool:
+    guild = getattr(destination, "guild", None)
+    bot_member = getattr(guild, "me", None)
+    permissions_for = getattr(destination, "permissions_for", None)
+    if bot_member is None or not callable(permissions_for):
+        return False
+    permissions = permissions_for(bot_member)
+    return bool(getattr(permissions, "manage_messages", False))
 
 
 async def send_every_code_message(
@@ -13,19 +28,52 @@ async def send_every_code_message(
     *,
     view: discord.ui.View | None = None,
 ) -> discord.Message:
+    if can_suppress_embeds(destination):
+        try:
+            if view is None:
+                return await destination.send(
+                    content,
+                    allowed_mentions=every_code_allowed_mentions(),
+                    suppress_embeds=True,
+                )
+
+            return await destination.send(
+                content,
+                allowed_mentions=every_code_allowed_mentions(),
+                suppress_embeds=True,
+                view=view,
+            )
+        except discord.Forbidden:
+            logger.warning("Unable to suppress Every Code embeds despite apparent Manage Messages permission")
+
     if view is None:
-        return await destination.send(
+        message = await destination.send(
             content,
             allowed_mentions=every_code_allowed_mentions(),
-            suppress_embeds=True,
+        )
+    else:
+        message = await destination.send(
+            content,
+            allowed_mentions=every_code_allowed_mentions(),
+            view=view,
         )
 
-    return await destination.send(
-        content,
-        allowed_mentions=every_code_allowed_mentions(),
-        suppress_embeds=True,
-        view=view,
-    )
+    await notify_missing_manage_messages(destination)
+    return message
+
+
+async def notify_missing_manage_messages(destination: discord.abc.Messageable) -> None:
+    destination_id = getattr(destination, "id", id(destination))
+    if destination_id in MISSING_MANAGE_MESSAGES_DESTINATIONS:
+        return
+    MISSING_MANAGE_MESSAGES_DESTINATIONS.add(destination_id)
+    try:
+        await destination.send(
+            "Every Code could not suppress link previews because I am missing the `Manage Messages` permission here.",
+            allowed_mentions=every_code_allowed_mentions(),
+        )
+    except discord.DiscordException:
+        logger.warning("Unable to post Every Code missing Manage Messages notice in %s", destination_id)
 
 
 async def edit_every_code_message(message: discord.Message, *, content: str) -> discord.Message:

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -78,10 +78,19 @@ class FakeReplyMessage:
 
 
 class FakeThread:
-    def __init__(self, thread_id: int, *, archived: bool = False, locked: bool = False) -> None:
+    def __init__(
+        self,
+        thread_id: int,
+        *,
+        archived: bool = False,
+        locked: bool = False,
+        manage_messages: bool = True,
+    ) -> None:
         self.id = thread_id
         self.archived = archived
         self.locked = locked
+        self.guild = SimpleNamespace(me=SimpleNamespace(id=999))
+        self._manage_messages = manage_messages
         self._messages: dict[int, FakeReplyMessage] = {}
         self._history: list[FakeReplyMessage] = []
         self.sent_messages: list[str] = []
@@ -92,6 +101,9 @@ class FakeThread:
     def add_message(self, message: FakeReplyMessage) -> None:
         self._messages[message.id] = message
         self._history.append(message)
+
+    def permissions_for(self, _member: object) -> object:
+        return SimpleNamespace(manage_messages=self._manage_messages)
 
     def delete_message(self, message_id: int) -> None:
         message = self._messages.pop(message_id, None)
@@ -141,8 +153,10 @@ class FakeThread:
 
 
 class FakeTextChannel:
-    def __init__(self, channel_id: int, threads: list[FakeThread]) -> None:
+    def __init__(self, channel_id: int, threads: list[FakeThread], *, manage_messages: bool = True) -> None:
         self.id = channel_id
+        self.guild = SimpleNamespace(me=SimpleNamespace(id=999))
+        self._manage_messages = manage_messages
         self.threads = [thread for thread in threads if not thread.archived]
         self._archived_threads = [thread for thread in threads if thread.archived]
         self.sent_messages: list[str] = []
@@ -152,8 +166,11 @@ class FakeTextChannel:
         for thread in self._archived_threads:
             yield thread
 
+    def permissions_for(self, _member: object) -> object:
+        return SimpleNamespace(manage_messages=self._manage_messages)
+
     async def create_thread(self, **kwargs: object) -> FakeThread:
-        thread = FakeThread(9000 + len(self.threads))
+        thread = FakeThread(9000 + len(self.threads), manage_messages=self._manage_messages)
         self.threads.append(thread)
         return thread
 

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -58,6 +58,7 @@ write_default_config()
 Config = importlib.import_module("discord_blue.config").Config
 bridge_module = importlib.import_module("discord_blue.doodads.every_code.bridge")
 EveryCodeBridge = bridge_module.EveryCodeBridge
+messages_module = importlib.import_module("discord_blue.doodads.every_code.messages")
 protocol_module = importlib.import_module("discord_blue.doodads.every_code.protocol")
 RemoteCommand = protocol_module.RemoteCommand
 RemoteApprovalRequest = protocol_module.RemoteApprovalRequest
@@ -304,9 +305,11 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.original_text_channel_type = threads_module.discord.TextChannel
         threads_module.discord.TextChannel = FakeTextChannel
+        messages_module.MISSING_MANAGE_MESSAGES_DESTINATIONS.clear()
 
     async def asyncTearDown(self) -> None:
         threads_module.discord.TextChannel = self.original_text_channel_type
+        messages_module.MISSING_MANAGE_MESSAGES_DESTINATIONS.clear()
 
     async def test_create_session_thread_suppresses_embeds_on_start_messages(self) -> None:
         config = Config()
@@ -317,6 +320,29 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(channel.sent_kwargs[0]["suppress_embeds"])
         self.assertTrue(session_thread.thread.sent_kwargs[0]["suppress_embeds"])
+
+    async def test_create_session_thread_warns_when_manage_messages_missing(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [], manage_messages=False)
+
+        session_thread = await create_session_thread(FakeBot(config, channel=channel), make_hello())
+
+        self.assertNotIn("suppress_embeds", channel.sent_kwargs[0])
+        self.assertIn("missing the `Manage Messages` permission", channel.sent_messages[1])
+        self.assertNotIn("suppress_embeds", session_thread.thread.sent_kwargs[0])
+        self.assertIn("missing the `Manage Messages` permission", session_thread.thread.sent_messages[1])
+
+    async def test_missing_manage_messages_notice_posts_once_per_destination(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [], manage_messages=False)
+
+        await create_session_thread(FakeBot(config, channel=channel), make_hello())
+        await messages_module.send_every_code_message(channel, "Second message")
+
+        notices = [message for message in channel.sent_messages if "missing the `Manage Messages` permission" in message]
+        self.assertEqual(len(notices), 1)
 
     def test_session_thread_text_uses_repo_branch_and_no_mentions(self) -> None:
         hello = make_hello()


### PR DESCRIPTION
## Summary
- check whether the bot has Manage Messages before using Discord's suppress_embeds send flag
- fall back to normal sends when the permission is missing so Every Code message delivery still works
- post a one-time per-destination notice that Manage Messages is needed to suppress link previews
- extend fakes/tests for permission-present, permission-missing, and one-time notice behavior

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q