### PR TITLE
Harden Every Code missing permission warning

### DIFF
--- a/discord_blue/doodads/every_code/messages.py
+++ b/discord_blue/doodads/every_code/messages.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
 
 logger = logging.getLogger(__name__)
 MISSING_MANAGE_MESSAGES_DESTINATIONS: set[int] = set()
+MISSING_MANAGE_MESSAGES_NOTICE_LOCK = asyncio.Lock()
 
 
 def every_code_allowed_mentions() -> discord.AllowedMentions:
@@ -64,16 +66,18 @@ async def send_every_code_message(
 
 async def notify_missing_manage_messages(destination: discord.abc.Messageable) -> None:
     destination_id = getattr(destination, "id", id(destination))
-    if destination_id in MISSING_MANAGE_MESSAGES_DESTINATIONS:
-        return
-    MISSING_MANAGE_MESSAGES_DESTINATIONS.add(destination_id)
-    try:
-        await destination.send(
-            "Every Code could not suppress link previews because I am missing the `Manage Messages` permission here.",
-            allowed_mentions=every_code_allowed_mentions(),
-        )
-    except discord.DiscordException:
-        logger.warning("Unable to post Every Code missing Manage Messages notice in %s", destination_id)
+    async with MISSING_MANAGE_MESSAGES_NOTICE_LOCK:
+        if destination_id in MISSING_MANAGE_MESSAGES_DESTINATIONS:
+            return
+        try:
+            await destination.send(
+                "Every Code could not suppress link previews because I am missing the `Manage Messages` permission here.",
+                allowed_mentions=every_code_allowed_mentions(),
+            )
+        except discord.DiscordException:
+            logger.warning("Unable to post Every Code missing Manage Messages notice in %s", destination_id)
+            return
+        MISSING_MANAGE_MESSAGES_DESTINATIONS.add(destination_id)
 
 
 async def edit_every_code_message(message: discord.Message, *, content: str) -> discord.Message:

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -96,6 +96,8 @@ class FakeThread:
         self.sent_messages: list[str] = []
         self.sent_views: list[object] = []
         self.sent_kwargs: list[dict[str, object]] = []
+        self.send_raises = False
+        self.send_failures_remaining = 0
         self.edits: list[dict[str, object]] = []
 
     def add_message(self, message: FakeReplyMessage) -> None:
@@ -131,6 +133,13 @@ class FakeThread:
             yield message
 
     async def send(self, content: str | None = None, **kwargs: object) -> FakeReplyMessage:
+        if self.send_raises or self.send_failures_remaining > 0:
+            if self.send_failures_remaining > 0:
+                self.send_failures_remaining -= 1
+            raise discord.Forbidden(
+                response=SimpleNamespace(status=403, reason="Forbidden"),
+                message=f"Cannot send to {self.id}",
+            )
         stored_content = content or ""
         self.sent_messages.append(stored_content)
         self.sent_views.append(kwargs.get("view"))

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -344,6 +344,27 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         notices = [message for message in channel.sent_messages if "missing the `Manage Messages` permission" in message]
         self.assertEqual(len(notices), 1)
 
+    async def test_missing_manage_messages_notice_retries_after_send_failure(self) -> None:
+        thread = FakeThread(555, manage_messages=False)
+        thread.send_failures_remaining = 1
+
+        await messages_module.notify_missing_manage_messages(thread)
+        await messages_module.send_every_code_message(thread, "Second message")
+
+        notices = [message for message in thread.sent_messages if "missing the `Manage Messages` permission" in message]
+        self.assertEqual(len(notices), 1)
+
+    async def test_missing_manage_messages_notice_is_atomic_per_destination(self) -> None:
+        thread = FakeThread(555, manage_messages=False)
+
+        await asyncio.gather(
+            messages_module.send_every_code_message(thread, "First message"),
+            messages_module.send_every_code_message(thread, "Second message"),
+        )
+
+        notices = [message for message in thread.sent_messages if "missing the `Manage Messages` permission" in message]
+        self.assertEqual(len(notices), 1)
+
     def test_session_thread_text_uses_repo_branch_and_no_mentions(self) -> None:
         hello = make_hello()
         thread = SimpleNamespace(id=555)


### PR DESCRIPTION
## Summary
- make the missing Manage Messages warning guard atomic with a lock
- mark a destination as warned only after the warning message sends successfully
- add tests for transient warning-send failure retry and concurrent send dedupe

## Validation
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv run python -m unittest discover -s tests -q