### PR TITLE
Fix Every Code automated notification cleanup

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -54,6 +54,10 @@ SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = 2
 SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS = 5
 SESSION_START_PREFIX = "Every Code session connected"
 SESSION_NOTIFICATION_PREFIX = "Every Code session connected for "
+SESSION_NOTIFICATION_PREFIXES = (
+    SESSION_NOTIFICATION_PREFIX,
+    "Every Code automated session connected for ",
+)
 MARKDOWN_CODE_FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?P<info>[^`~\n]*)$")
 RESUME_SESSION_RE = re.compile(
     r"\bresume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b",
@@ -381,7 +385,7 @@ class EveryCodeBridge:
             async for message in channel.history():
                 if message.author.id != bot_user.id:
                     continue
-                if not message.content.startswith(SESSION_NOTIFICATION_PREFIX):
+                if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):
                     continue
                 try:
                     await message.delete()

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -31,7 +31,7 @@ class FakeReplyMessage:
     def __init__(
         self,
         message_id: int,
-        channel: FakeThread,
+        channel: FakeThread | FakeTextChannel,
         content: str = "",
         *,
         author_id: int = 123,
@@ -168,8 +168,34 @@ class FakeTextChannel:
         self._manage_messages = manage_messages
         self.threads = [thread for thread in threads if not thread.archived]
         self._archived_threads = [thread for thread in threads if thread.archived]
+        self._messages: dict[int, FakeReplyMessage] = {}
+        self._history: list[FakeReplyMessage] = []
         self.sent_messages: list[str] = []
         self.sent_kwargs: list[dict[str, object]] = []
+
+    def add_message(self, message: FakeReplyMessage) -> None:
+        self._messages[message.id] = message
+        self._history.append(message)
+
+    def delete_message(self, message_id: int) -> None:
+        message = self._messages.pop(message_id, None)
+        if message is None:
+            return
+        message.deleted = True
+        self._history = [stored for stored in self._history if stored.id != message_id]
+
+    async def history(
+        self,
+        limit: int | None = None,
+        oldest_first: bool = False,
+    ) -> AsyncIterator[FakeReplyMessage]:
+        messages = list(self._history)
+        if not oldest_first:
+            messages.reverse()
+        if limit is not None:
+            messages = messages[:limit]
+        for message in messages:
+            yield message
 
     async def archived_threads(self, **_: object) -> AsyncIterator[FakeThread]:
         for thread in self._archived_threads:
@@ -187,7 +213,9 @@ class FakeTextChannel:
         stored_content = content or ""
         self.sent_messages.append(stored_content)
         self.sent_kwargs.append(kwargs)
-        return FakeReplyMessage(800 + len(self.sent_messages), FakeThread(self.id), stored_content)
+        message = FakeReplyMessage(800 + len(self.sent_messages), self, stored_content, author_id=999)
+        self.add_message(message)
+        return message
 
 
 class FakeInteractionResponse:
@@ -252,7 +280,7 @@ def make_hello() -> SessionHello:
     )
 
 
-def add_bot_message(thread: FakeThread, message_id: int, content: str) -> FakeReplyMessage:
-    message = FakeReplyMessage(message_id, thread, content, author_id=999)
-    thread.add_message(message)
+def add_bot_message(channel: FakeThread | FakeTextChannel, message_id: int, content: str) -> FakeReplyMessage:
+    message = FakeReplyMessage(message_id, channel, content, author_id=999)
+    channel.add_message(message)
     return message

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -500,6 +500,37 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(bridge._authorized(SimpleNamespace(headers={"Authorization": "Bearer wrong"})))
         self.assertTrue(bridge._authorized(SimpleNamespace(headers={"Authorization": "Bearer shared-secret"})))
 
+    async def test_cleanup_stale_session_notifications_deletes_human_and_automated_notices(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        human_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project` on `main`: <#555>",
+        )
+        automated_notice = add_bot_message(
+            channel,
+            102,
+            "Every Code automated session connected for `cbusillo/sellyouroutboard#67`: <#556>",
+        )
+        unrelated_bot_notice = add_bot_message(channel, 103, "Every Code status summary")
+        user_notice = FakeReplyMessage(
+            104,
+            channel,
+            "Every Code automated session connected for `user/post`: <#557>",
+            author_id=123,
+        )
+        channel.add_message(user_notice)
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+
+        await bridge.cleanup_stale_session_notifications()
+
+        self.assertTrue(human_notice.deleted)
+        self.assertTrue(automated_notice.deleted)
+        self.assertFalse(unrelated_bot_notice.deleted)
+        self.assertFalse(user_notice.deleted)
+
     async def test_stop_disconnects_sessions_before_runner_cleanup(self) -> None:
         config = Config()
         bridge = EveryCodeBridge(FakeBot(config))


### PR DESCRIPTION
## Summary
- clean up stale Every Code automated session notification messages alongside normal session notices
- extend fake text channel history/deletion support so cleanup behavior is covered through the real loop

## Verification
- `uv run python -m unittest tests.test_every_code.BridgeTests.test_cleanup_stale_session_notifications_deletes_human_and_automated_notices -q`
- `uv run python -m unittest discover -s tests -q`
- `uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py`
- `uv run ruff check --diff discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py`
- `uv run ruff check discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py`
- `uv run mypy .`
