### PR TITLE
Use github.json for workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -33,7 +33,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -46,12 +50,13 @@
       "systemd or container wiring changes"
     ]
   },
-  "importantWorkflows": ["Deploy to Production"],
+  "importantWorkflows": [
+    "Deploy to Production"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [],
-  "validatedThrough": ["Deploy to Production"],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ same managed environment. After `uv sync`, IDEs may point at the repo-local
 Use `uv run mypy .` for static type checking.
 Use `uv run ruff check .` for linting.
 Use `uv run ruff format .` for formatting.
-Use `.github/github-repo-workflow.json` for non-secret repo workflow facts,
+Use `.github/github.json` for non-secret repo workflow facts,
 validation commands, GitHub signal availability, docs routing, important
 workflows, and cleanup policy.
 


### PR DESCRIPTION
## Summary
- rename repo workflow metadata from `.github/github-repo-workflow.json` to `.github/github.json`
- update local guidance/docs to point at the canonical metadata path
- drop retired `validatedThrough` metadata while preserving the rest of the workflow facts

## Validation
- `jq empty .github/github.json`
- confirmed `.github/github-repo-workflow.json` is removed
- confirmed repo docs no longer reference `.github/github-repo-workflow.json`
- confirmed `.github/github.json` has no `validatedThrough` / `validated-through` entries
- compared old and new JSON content, allowing only the retired `validatedThrough` field/trigger removal
- `git diff --check`
