### PR TITLE
Rename Every Code threads for working branches

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -25,6 +25,7 @@ from discord_blue.doodads.every_code.protocol import (
     RemoteCommand,
     RemoteRequestUserInput,
     SessionHello,
+    SessionMetadataChanged,
     SessionStatus,
     UserMessage,
 )
@@ -40,7 +41,9 @@ from discord_blue.doodads.every_code.threads import SessionThread
 from discord_blue.doodads.every_code.threads import auto_join_configured_users
 from discord_blue.doodads.every_code.threads import create_session_thread
 from discord_blue.doodads.every_code.threads import get_every_code_channel
+from discord_blue.doodads.every_code.threads import session_branch_is_title_worthy
 from discord_blue.doodads.every_code.threads import session_display_name
+from discord_blue.doodads.every_code.threads import session_thread_name
 from discord_blue.doodads.every_code.threads import session_start_message
 from discord_blue.plugs.discord_plug import BlueBot
 
@@ -478,6 +481,9 @@ class EveryCodeBridge:
                 await websocket.send_json({"type": "hello_ack", "thread_id": session_thread.thread.id})
             elif message_type == "heartbeat" and session is not None:
                 session.touch()
+            elif message_type == "session_metadata_changed":
+                metadata = SessionMetadataChanged.from_payload(payload)
+                await self.handle_session_metadata_changed(metadata)
             elif message_type == "user_message":
                 user_message = UserMessage.from_payload(payload)
                 await self.handle_user_message(user_message)
@@ -903,7 +909,7 @@ class EveryCodeBridge:
         lines = ["Live Every Code sessions:"]
         for session in sessions:
             repo = session_display_name(session.hello)
-            branch = f" on `{session.hello.branch}`" if session.hello.branch else ""
+            branch = f" on `{session.hello.branch}`" if session_branch_is_title_worthy(session.hello.branch) else ""
             thread = f" <#{session.thread_id}>" if session.thread_id is not None else ""
             state = "offline" if session.websocket.closed else "online"
             lines.append(f"- `{repo}`{branch} ({state}, {session.hello.host_label}){thread}")
@@ -924,7 +930,7 @@ class EveryCodeBridge:
             return "This thread is not attached to a live Every Code session."
 
         repo = session_display_name(session.hello)
-        branch = f" on `{session.hello.branch}`" if session.hello.branch else ""
+        branch = f" on `{session.hello.branch}`" if session_branch_is_title_worthy(session.hello.branch) else ""
         state = "offline" if session.websocket.closed else "online"
         status = session.last_status_message or "No status update received yet."
         return "\n".join(
@@ -1428,6 +1434,31 @@ class EveryCodeBridge:
                 if replaced:
                     return
             await self.post_session_controls(session)
+
+    async def handle_session_metadata_changed(self, metadata: SessionMetadataChanged) -> None:
+        session = self.sessions.get(metadata.session_id)
+        if session is None or session.thread_id is None:
+            logger.warning("Every Code metadata update for unknown session: %s", metadata.session_id)
+            return
+        if metadata.session_epoch != session.session_epoch:
+            logger.warning("Every Code metadata update for stale session epoch: %s", metadata.session_id)
+            return
+
+        old_name = session_thread_name(session.hello)
+        if metadata.branch is not None:
+            session.hello.branch = metadata.branch
+        new_name = session_thread_name(session.hello)
+        if metadata.reason != "working_branch_selected" or session.hello.origin is not None or new_name == old_name:
+            return
+
+        thread = await self.get_thread(session.thread_id)
+        if thread is None:
+            logger.warning("Unable to rename Every Code thread %s: thread is unavailable", session.thread_id)
+            return
+        try:
+            await thread.edit(name=new_name, reason="Every Code working branch selected")
+        except discord.DiscordException:
+            logger.warning("Unable to rename Every Code thread %s", session.thread_id)
 
     async def handle_user_message(self, user_message: UserMessage) -> None:
         session = self.sessions.get(user_message.session_id)

--- a/discord_blue/doodads/every_code/protocol.py
+++ b/discord_blue/doodads/every_code/protocol.py
@@ -54,6 +54,25 @@ class SessionHello:
 
 
 @dataclass(slots=True)
+class SessionMetadataChanged:
+    session_id: str
+    session_epoch: str
+    cwd: str | None
+    branch: str | None
+    reason: str
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "SessionMetadataChanged":
+        return cls(
+            session_id=str(payload["session_id"]),
+            session_epoch=str(payload["session_epoch"]),
+            cwd=str(payload["cwd"]) if payload.get("cwd") else None,
+            branch=str(payload["branch"]) if payload.get("branch") else None,
+            reason=str(payload.get("reason") or ""),
+        )
+
+
+@dataclass(slots=True)
 class SessionStatus:
     session_id: str
     session_epoch: str

--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -12,6 +12,7 @@ from discord_blue.plugs.discord_plug import BlueBot
 
 logger = logging.getLogger(__name__)
 DISCORD_THREAD_NAME_LIMIT = 100
+DEFAULT_BRANCH_NAMES = {"main", "master", "develop", "development", "dev", "trunk"}
 
 
 @dataclass(slots=True)
@@ -24,8 +25,12 @@ def session_thread_name(hello: SessionHello) -> str:
     repo = session_display_name(hello)
     if hello.origin and hello.origin.kind == "every_code":
         return _truncate_thread_name(repo)
-    branch = f" · {hello.branch}" if hello.branch else ""
+    branch = f" · {hello.branch}" if session_branch_is_title_worthy(hello.branch) else ""
     return _truncate_thread_name(f"{repo}{branch}")
+
+
+def session_branch_is_title_worthy(branch: str | None) -> bool:
+    return bool(branch and branch.lower() not in DEFAULT_BRANCH_NAMES)
 
 
 def session_display_name(hello: SessionHello) -> str:
@@ -79,7 +84,7 @@ def session_notification_message(hello: SessionHello, thread: discord.Thread) ->
         issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
         repo = f"{hello.origin.repository}{issue}"
         prefix = "Every Code automated session connected"
-    branch = f" on `{hello.branch}`" if hello.branch else ""
+    branch = f" on `{hello.branch}`" if session_branch_is_title_worthy(hello.branch) else ""
     return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
 
 

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -99,6 +99,7 @@ class FakeThread:
         self.send_raises = False
         self.send_failures_remaining = 0
         self.edits: list[dict[str, object]] = []
+        self.name: str | None = None
 
     def add_message(self, message: FakeReplyMessage) -> None:
         self._messages[message.id] = message
@@ -158,6 +159,8 @@ class FakeThread:
             self.archived = bool(kwargs["archived"])
         if "locked" in kwargs:
             self.locked = bool(kwargs["locked"])
+        if "name" in kwargs:
+            self.name = str(kwargs["name"])
         self.edits.append(kwargs)
 
 
@@ -260,6 +263,7 @@ class FakeBot:
         self.user = SimpleNamespace(id=999)
         self._thread = thread
         self._channel = channel
+        self.fetch_channel_calls: list[int] = []
 
     def get_channel(self, channel_id: int) -> FakeThread | FakeTextChannel | None:
         if self._thread is not None and self._thread.id == channel_id:
@@ -267,6 +271,26 @@ class FakeBot:
         if self._channel is not None and self._channel.id == channel_id:
             return self._channel
         return None
+
+    async def fetch_channel(self, channel_id: int) -> FakeThread | FakeTextChannel:
+        self.fetch_channel_calls.append(channel_id)
+        channel = self.get_channel(channel_id)
+        if channel is not None:
+            return channel
+        raise discord.NotFound(SimpleNamespace(status=404, reason="Not Found"), "channel not found")
+
+
+class FetchOnlyFakeBot(FakeBot):
+    def get_channel(self, channel_id: int) -> None:
+        return None
+
+    async def fetch_channel(self, channel_id: int) -> FakeThread | FakeTextChannel:
+        self.fetch_channel_calls.append(channel_id)
+        if self._thread is not None and self._thread.id == channel_id:
+            return self._thread
+        if self._channel is not None and self._channel.id == channel_id:
+            return self._channel
+        raise discord.NotFound(SimpleNamespace(status=404, reason="Not Found"), "channel not found")
 
 
 def make_hello() -> SessionHello:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from tests.fakes_every_code import FakeBot
+from tests.fakes_every_code import FetchOnlyFakeBot
 from tests.fakes_every_code import FakeInteraction
 from tests.fakes_every_code import FakeReplyMessage
 from tests.fakes_every_code import FakeTextChannel
@@ -66,6 +67,7 @@ RemoteRequestUserInput = protocol_module.RemoteRequestUserInput
 RequestUserInputQuestion = protocol_module.RequestUserInputQuestion
 RequestUserInputQuestionOption = protocol_module.RequestUserInputQuestionOption
 SessionHello = protocol_module.SessionHello
+SessionMetadataChanged = protocol_module.SessionMetadataChanged
 SessionOrigin = protocol_module.SessionOrigin
 SessionStatus = protocol_module.SessionStatus
 sessions_module = importlib.import_module("discord_blue.doodads.every_code.sessions")
@@ -199,6 +201,23 @@ class ProtocolTests(unittest.TestCase):
         self.assertEqual(hello.origin.kind, "every_code")
         self.assertEqual(hello.origin.repository, "cbusillo/sellyouroutboard")
         self.assertEqual(hello.origin.issue_number, 67)
+
+    def test_session_metadata_changed_from_payload(self) -> None:
+        metadata = SessionMetadataChanged.from_payload(
+            {
+                "session_id": "session-1",
+                "session_epoch": "epoch-1",
+                "cwd": "/tmp/project-worktree",
+                "branch": "code/project-task",
+                "reason": "working_branch_selected",
+            }
+        )
+
+        self.assertEqual(metadata.session_id, "session-1")
+        self.assertEqual(metadata.session_epoch, "epoch-1")
+        self.assertEqual(metadata.cwd, "/tmp/project-worktree")
+        self.assertEqual(metadata.branch, "code/project-task")
+        self.assertEqual(metadata.reason, "working_branch_selected")
 
     def test_remote_command_serializes_bridge_message(self) -> None:
         command = RemoteCommand(
@@ -369,10 +388,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         hello = make_hello()
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "project · main")
+        self.assertEqual(session_thread_name(hello), "project")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `project` on `main`: <#555>",
+            "Every Code session connected for `project`: <#555>",
         )
         self.assertEqual(
             session_start_message(hello),
@@ -405,6 +424,30 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
             "Every Code session connected for `session`: <#555>",
         )
         self.assertIn("branch: `unknown`", session_start_message(hello))
+
+    def test_session_thread_text_includes_non_default_branch(self) -> None:
+        hello = make_hello()
+        hello.branch = "code/project-task"
+        thread = SimpleNamespace(id=555)
+
+        self.assertEqual(session_thread_name(hello), "project · code/project-task")
+        self.assertEqual(
+            session_notification_message(hello, thread),
+            "Every Code session connected for `project` on `code/project-task`: <#555>",
+        )
+
+    def test_session_thread_text_omits_common_default_branch_names(self) -> None:
+        thread = SimpleNamespace(id=555)
+
+        for branch in ["main", "master", "develop", "development", "dev", "trunk", "MAIN"]:
+            hello = make_hello()
+            hello.branch = branch
+
+            self.assertEqual(session_thread_name(hello), "project")
+            self.assertEqual(
+                session_notification_message(hello, thread),
+                "Every Code session connected for `project`: <#555>",
+            )
 
     def test_session_thread_text_marks_every_code_origin(self) -> None:
         hello = SessionHello(
@@ -1873,7 +1916,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(
                 [
                     "Live Every Code sessions:",
-                    "- `project` on `main` (online, Mac Studio) <#555>",
+                    "- `project` (online, Mac Studio) <#555>",
                 ]
             ),
         )
@@ -1915,7 +1958,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(
                 [
                     "Live Every Code sessions:",
-                    "- `EC sellyouroutboard#67` on `main` (online, Mac Studio) <#555>",
+                    "- `EC sellyouroutboard#67` (online, Mac Studio) <#555>",
                 ]
             ),
         )
@@ -1947,7 +1990,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             bridge.session_status_summary(thread, SimpleNamespace(id=123)),
             "\n".join(
                 [
-                    "Every Code `project` on `main`",
+                    "Every Code `project`",
                     "state: online",
                     "host: Mac Studio",
                     "status: Turn started",
@@ -1987,13 +2030,129 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             bridge.session_status_summary(thread, SimpleNamespace(id=123)),
             "\n".join(
                 [
-                    "Every Code `EC sellyouroutboard#67` on `main`",
+                    "Every Code `EC sellyouroutboard#67`",
                     "state: online",
                     "host: Mac Studio",
                     "status: No status update received yet.",
                 ]
             ),
         )
+
+    async def test_session_metadata_changed_renames_human_thread_to_working_branch(self) -> None:
+        config = Config()
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.handle_session_metadata_changed(
+            SessionMetadataChanged(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                cwd="/tmp/project-worktree",
+                branch="code/project-task",
+                reason="working_branch_selected",
+            )
+        )
+
+        self.assertEqual(session.hello.cwd, "/tmp/project")
+        self.assertEqual(session.hello.branch, "code/project-task")
+        self.assertEqual(thread.name, "project · code/project-task")
+        self.assertEqual(thread.edits[-1]["reason"], "Every Code working branch selected")
+
+    async def test_session_metadata_changed_preserves_missing_branch(self) -> None:
+        config = Config()
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.handle_session_metadata_changed(
+            SessionMetadataChanged(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                cwd="/tmp/project-worktree",
+                branch=None,
+                reason="working_branch_selected",
+            )
+        )
+
+        self.assertEqual(session.hello.cwd, "/tmp/project")
+        self.assertEqual(session.hello.branch, "main")
+        self.assertIsNone(thread.name)
+        self.assertEqual(thread.edits, [])
+
+    async def test_session_metadata_changed_fetches_uncached_thread_before_renaming(self) -> None:
+        config = Config()
+        thread = FakeThread(555)
+        bot = FetchOnlyFakeBot(config, thread)
+        bridge = EveryCodeBridge(bot)
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.handle_session_metadata_changed(
+            SessionMetadataChanged(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                cwd="/tmp/project-worktree",
+                branch="code/project-task",
+                reason="working_branch_selected",
+            )
+        )
+
+        self.assertEqual(bot.fetch_channel_calls, [555])
+        self.assertEqual(thread.name, "project · code/project-task")
+
+    async def test_session_metadata_changed_skips_every_code_origin_rename(self) -> None:
+        config = Config()
+        thread = FakeThread(555)
+        bridge = EveryCodeBridge(FakeBot(config, thread))
+        hello = SessionHello(
+            session_id="session-1",
+            session_epoch="epoch-1",
+            host_label="Mac Studio",
+            cwd="/tmp/project",
+            branch="main",
+            pid=42,
+            origin=SessionOrigin(
+                kind="every_code",
+                request_id="every-code-cbusillo-syo-67",
+                repository="cbusillo/sellyouroutboard",
+                issue_number=67,
+                issue_url="https://github.com/cbusillo/sellyouroutboard/issues/67",
+            ),
+        )
+        session = EveryCodeSession(hello=hello, websocket=FakeWebSocket(), thread_id=555)
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.handle_session_metadata_changed(
+            SessionMetadataChanged(
+                session_id="session-1",
+                session_epoch="epoch-1",
+                cwd="/tmp/project-worktree",
+                branch="code/project-task",
+                reason="working_branch_selected",
+            )
+        )
+
+        self.assertEqual(session.hello.branch, "code/project-task")
+        self.assertEqual(thread.edits, [])
 
     async def test_reconnect_reuses_matching_thread_with_assistant_history(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- hide common default branch names in Every Code thread titles, notifications, and status summaries
- accept Code session metadata updates and rename human/local Discord threads when Code selects a working branch
- keep automated issue sessions issue-named and fetch uncached threads before renaming

## Tests
- uv run ruff format --check discord_blue/doodads/every_code/protocol.py discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/protocol.py discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/fakes_every_code.py tests/test_every_code.py
- uv run python -m unittest tests.test_every_code -q
- uv run mypy discord_blue/doodads/every_code tests/test_every_code.py