### PR TITLE
Differentiate Every Code session threads

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -41,8 +41,6 @@ from discord_blue.doodads.every_code.threads import SessionThread
 from discord_blue.doodads.every_code.threads import auto_join_configured_users
 from discord_blue.doodads.every_code.threads import create_session_thread
 from discord_blue.doodads.every_code.threads import get_every_code_channel
-from discord_blue.doodads.every_code.threads import session_branch_is_title_worthy
-from discord_blue.doodads.every_code.threads import session_display_name
 from discord_blue.doodads.every_code.threads import session_thread_name
 from discord_blue.doodads.every_code.threads import session_start_message
 from discord_blue.plugs.discord_plug import BlueBot
@@ -908,11 +906,10 @@ class EveryCodeBridge:
 
         lines = ["Live Every Code sessions:"]
         for session in sessions:
-            repo = session_display_name(session.hello)
-            branch = f" on `{session.hello.branch}`" if session_branch_is_title_worthy(session.hello.branch) else ""
+            title = session_thread_name(session.hello)
             thread = f" <#{session.thread_id}>" if session.thread_id is not None else ""
             state = "offline" if session.websocket.closed else "online"
-            lines.append(f"- `{repo}`{branch} ({state}, {session.hello.host_label}){thread}")
+            lines.append(f"- `{title}` ({state}, {session.hello.host_label}){thread}")
         return "\n".join(lines)
 
     def session_status_summary(
@@ -929,13 +926,12 @@ class EveryCodeBridge:
         if session is None:
             return "This thread is not attached to a live Every Code session."
 
-        repo = session_display_name(session.hello)
-        branch = f" on `{session.hello.branch}`" if session_branch_is_title_worthy(session.hello.branch) else ""
+        title = session_thread_name(session.hello)
         state = "offline" if session.websocket.closed else "online"
         status = session.last_status_message or "No status update received yet."
         return "\n".join(
             [
-                f"Every Code `{repo}`{branch}",
+                f"Every Code `{title}`",
                 f"state: {state}",
                 f"host: {session.hello.host_label}",
                 f"status: {status}",

--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 import discord
@@ -26,7 +27,25 @@ def session_thread_name(hello: SessionHello) -> str:
     if hello.origin and hello.origin.kind == "every_code":
         return _truncate_thread_name(repo)
     branch = f" · {hello.branch}" if session_branch_is_title_worthy(hello.branch) else ""
-    return _truncate_thread_name(f"{repo}{branch}")
+    discriminator = f" · {session_discriminator(hello)}"
+    return _truncate_thread_name(f"{repo}{branch}{discriminator}")
+
+
+def session_discriminator(hello: SessionHello) -> str:
+    short_id = _short_session_id(hello.session_id)
+    try:
+        epoch_millis = int(hello.session_epoch)
+    except ValueError:
+        return short_id
+    if epoch_millis <= 0:
+        return short_id
+    started = datetime.fromtimestamp(epoch_millis / 1000)
+    return f"{started:%H:%M} {short_id}"
+
+
+def _short_session_id(session_id: str) -> str:
+    short_id = "".join(char for char in session_id if char.isalnum())[:4]
+    return short_id or "sess"
 
 
 def session_branch_is_title_worthy(branch: str | None) -> bool:
@@ -78,14 +97,15 @@ def session_start_message(hello: SessionHello) -> str:
 
 
 def session_notification_message(hello: SessionHello, thread: discord.Thread) -> str:
-    repo = Path(hello.cwd).name or "session"
+    repo = session_thread_name(hello)
     prefix = "Every Code session connected"
     if hello.origin and hello.origin.kind == "every_code" and hello.origin.repository:
         issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
         repo = f"{hello.origin.repository}{issue}"
         prefix = "Every Code automated session connected"
-    branch = f" on `{hello.branch}`" if session_branch_is_title_worthy(hello.branch) else ""
-    return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
+        branch = f" on `{hello.branch}`" if session_branch_is_title_worthy(hello.branch) else ""
+        return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
+    return f"{prefix} for `{repo}`: <#{thread.id}>"
 
 
 async def get_every_code_channel(bot: BlueBot) -> discord.TextChannel:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -388,10 +388,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         hello = make_hello()
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "project")
+        self.assertEqual(session_thread_name(hello), "project · sess")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `project`: <#555>",
+            "Every Code session connected for `project · sess`: <#555>",
         )
         self.assertEqual(
             session_start_message(hello),
@@ -418,10 +418,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         )
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "session")
+        self.assertEqual(session_thread_name(hello), "session · sess")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `session`: <#555>",
+            "Every Code session connected for `session · sess`: <#555>",
         )
         self.assertIn("branch: `unknown`", session_start_message(hello))
 
@@ -430,11 +430,18 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         hello.branch = "code/project-task"
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "project · code/project-task")
+        self.assertEqual(session_thread_name(hello), "project · code/project-task · sess")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `project` on `code/project-task`: <#555>",
+            "Every Code session connected for `project · code/project-task · sess`: <#555>",
         )
+
+    def test_session_thread_text_uses_start_time_and_short_session_id(self) -> None:
+        hello = make_hello()
+        hello.session_id = "05ddf473-6cf3-4850-ac00-8f0a158d0c9d"
+        hello.session_epoch = "1710000000000"
+
+        self.assertRegex(session_thread_name(hello), r"^project · \d{2}:\d{2} 05dd$")
 
     def test_session_thread_text_omits_common_default_branch_names(self) -> None:
         thread = SimpleNamespace(id=555)
@@ -443,10 +450,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
             hello = make_hello()
             hello.branch = branch
 
-            self.assertEqual(session_thread_name(hello), "project")
+            self.assertEqual(session_thread_name(hello), "project · sess")
             self.assertEqual(
                 session_notification_message(hello, thread),
-                "Every Code session connected for `project`: <#555>",
+                "Every Code session connected for `project · sess`: <#555>",
             )
 
     def test_session_thread_text_marks_every_code_origin(self) -> None:
@@ -1916,7 +1923,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(
                 [
                     "Live Every Code sessions:",
-                    "- `project` (online, Mac Studio) <#555>",
+                    "- `project · sess` (online, Mac Studio) <#555>",
                 ]
             ),
         )
@@ -1990,7 +1997,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             bridge.session_status_summary(thread, SimpleNamespace(id=123)),
             "\n".join(
                 [
-                    "Every Code `project`",
+                    "Every Code `project · sess`",
                     "state: online",
                     "host: Mac Studio",
                     "status: Turn started",
@@ -2062,7 +2069,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(session.hello.cwd, "/tmp/project")
         self.assertEqual(session.hello.branch, "code/project-task")
-        self.assertEqual(thread.name, "project · code/project-task")
+        self.assertEqual(thread.name, "project · code/project-task · sess")
         self.assertEqual(thread.edits[-1]["reason"], "Every Code working branch selected")
 
     async def test_session_metadata_changed_preserves_missing_branch(self) -> None:
@@ -2116,7 +2123,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(bot.fetch_channel_calls, [555])
-        self.assertEqual(thread.name, "project · code/project-task")
+        self.assertEqual(thread.name, "project · code/project-task · sess")
 
     async def test_session_metadata_changed_skips_every_code_origin_rename(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- add a per-session discriminator to local Every Code thread titles
- use the same title in session notifications and status summaries
- keep automated issue-session titles unchanged

## Tests
- uv run python -m unittest tests.test_every_code -q
- uv run ruff format --check discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/test_every_code.py
- uv run mypy discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py tests/test_every_code.py