### PR TITLE
Revert Every Code thread title experiment

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -25,7 +25,6 @@ from discord_blue.doodads.every_code.protocol import (
     RemoteCommand,
     RemoteRequestUserInput,
     SessionHello,
-    SessionMetadataChanged,
     SessionStatus,
     UserMessage,
 )
@@ -479,9 +478,6 @@ class EveryCodeBridge:
                 await websocket.send_json({"type": "hello_ack", "thread_id": session_thread.thread.id})
             elif message_type == "heartbeat" and session is not None:
                 session.touch()
-            elif message_type == "session_metadata_changed":
-                metadata = SessionMetadataChanged.from_payload(payload)
-                await self.handle_session_metadata_changed(metadata)
             elif message_type == "user_message":
                 user_message = UserMessage.from_payload(payload)
                 await self.handle_user_message(user_message)
@@ -1430,31 +1426,6 @@ class EveryCodeBridge:
                 if replaced:
                     return
             await self.post_session_controls(session)
-
-    async def handle_session_metadata_changed(self, metadata: SessionMetadataChanged) -> None:
-        session = self.sessions.get(metadata.session_id)
-        if session is None or session.thread_id is None:
-            logger.warning("Every Code metadata update for unknown session: %s", metadata.session_id)
-            return
-        if metadata.session_epoch != session.session_epoch:
-            logger.warning("Every Code metadata update for stale session epoch: %s", metadata.session_id)
-            return
-
-        old_name = session_thread_name(session.hello)
-        if metadata.branch is not None:
-            session.hello.branch = metadata.branch
-        new_name = session_thread_name(session.hello)
-        if metadata.reason != "working_branch_selected" or session.hello.origin is not None or new_name == old_name:
-            return
-
-        thread = await self.get_thread(session.thread_id)
-        if thread is None:
-            logger.warning("Unable to rename Every Code thread %s: thread is unavailable", session.thread_id)
-            return
-        try:
-            await thread.edit(name=new_name, reason="Every Code working branch selected")
-        except discord.DiscordException:
-            logger.warning("Unable to rename Every Code thread %s", session.thread_id)
 
     async def handle_user_message(self, user_message: UserMessage) -> None:
         session = self.sessions.get(user_message.session_id)

--- a/discord_blue/doodads/every_code/protocol.py
+++ b/discord_blue/doodads/every_code/protocol.py
@@ -54,25 +54,6 @@ class SessionHello:
 
 
 @dataclass(slots=True)
-class SessionMetadataChanged:
-    session_id: str
-    session_epoch: str
-    cwd: str | None
-    branch: str | None
-    reason: str
-
-    @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "SessionMetadataChanged":
-        return cls(
-            session_id=str(payload["session_id"]),
-            session_epoch=str(payload["session_epoch"]),
-            cwd=str(payload["cwd"]) if payload.get("cwd") else None,
-            branch=str(payload["branch"]) if payload.get("branch") else None,
-            reason=str(payload.get("reason") or ""),
-        )
-
-
-@dataclass(slots=True)
 class SessionStatus:
     session_id: str
     session_epoch: str

--- a/discord_blue/doodads/every_code/threads.py
+++ b/discord_blue/doodads/every_code/threads.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 
 import discord
@@ -27,25 +26,7 @@ def session_thread_name(hello: SessionHello) -> str:
     if hello.origin and hello.origin.kind == "every_code":
         return _truncate_thread_name(repo)
     branch = f" · {hello.branch}" if session_branch_is_title_worthy(hello.branch) else ""
-    discriminator = f" · {session_discriminator(hello)}"
-    return _truncate_thread_name(f"{repo}{branch}{discriminator}")
-
-
-def session_discriminator(hello: SessionHello) -> str:
-    short_id = _short_session_id(hello.session_id)
-    try:
-        epoch_millis = int(hello.session_epoch)
-    except ValueError:
-        return short_id
-    if epoch_millis <= 0:
-        return short_id
-    started = datetime.fromtimestamp(epoch_millis / 1000)
-    return f"{started:%H:%M} {short_id}"
-
-
-def _short_session_id(session_id: str) -> str:
-    short_id = "".join(char for char in session_id if char.isalnum())[:4]
-    return short_id or "sess"
+    return _truncate_thread_name(f"{repo}{branch}")
 
 
 def session_branch_is_title_worthy(branch: str | None) -> bool:
@@ -97,15 +78,14 @@ def session_start_message(hello: SessionHello) -> str:
 
 
 def session_notification_message(hello: SessionHello, thread: discord.Thread) -> str:
-    repo = session_thread_name(hello)
+    repo = Path(hello.cwd).name or "session"
     prefix = "Every Code session connected"
     if hello.origin and hello.origin.kind == "every_code" and hello.origin.repository:
         issue = f"#{hello.origin.issue_number}" if hello.origin.issue_number is not None else ""
         repo = f"{hello.origin.repository}{issue}"
         prefix = "Every Code automated session connected"
-        branch = f" on `{hello.branch}`" if session_branch_is_title_worthy(hello.branch) else ""
-        return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
-    return f"{prefix} for `{repo}`: <#{thread.id}>"
+    branch = f" on `{hello.branch}`" if session_branch_is_title_worthy(hello.branch) else ""
+    return f"{prefix} for `{repo}`{branch}: <#{thread.id}>"
 
 
 async def get_every_code_channel(bot: BlueBot) -> discord.TextChannel:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -13,7 +13,6 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from tests.fakes_every_code import FakeBot
-from tests.fakes_every_code import FetchOnlyFakeBot
 from tests.fakes_every_code import FakeInteraction
 from tests.fakes_every_code import FakeReplyMessage
 from tests.fakes_every_code import FakeTextChannel
@@ -67,7 +66,6 @@ RemoteRequestUserInput = protocol_module.RemoteRequestUserInput
 RequestUserInputQuestion = protocol_module.RequestUserInputQuestion
 RequestUserInputQuestionOption = protocol_module.RequestUserInputQuestionOption
 SessionHello = protocol_module.SessionHello
-SessionMetadataChanged = protocol_module.SessionMetadataChanged
 SessionOrigin = protocol_module.SessionOrigin
 SessionStatus = protocol_module.SessionStatus
 sessions_module = importlib.import_module("discord_blue.doodads.every_code.sessions")
@@ -201,23 +199,6 @@ class ProtocolTests(unittest.TestCase):
         self.assertEqual(hello.origin.kind, "every_code")
         self.assertEqual(hello.origin.repository, "cbusillo/sellyouroutboard")
         self.assertEqual(hello.origin.issue_number, 67)
-
-    def test_session_metadata_changed_from_payload(self) -> None:
-        metadata = SessionMetadataChanged.from_payload(
-            {
-                "session_id": "session-1",
-                "session_epoch": "epoch-1",
-                "cwd": "/tmp/project-worktree",
-                "branch": "code/project-task",
-                "reason": "working_branch_selected",
-            }
-        )
-
-        self.assertEqual(metadata.session_id, "session-1")
-        self.assertEqual(metadata.session_epoch, "epoch-1")
-        self.assertEqual(metadata.cwd, "/tmp/project-worktree")
-        self.assertEqual(metadata.branch, "code/project-task")
-        self.assertEqual(metadata.reason, "working_branch_selected")
 
     def test_remote_command_serializes_bridge_message(self) -> None:
         command = RemoteCommand(
@@ -388,10 +369,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         hello = make_hello()
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "project · sess")
+        self.assertEqual(session_thread_name(hello), "project")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `project · sess`: <#555>",
+            "Every Code session connected for `project`: <#555>",
         )
         self.assertEqual(
             session_start_message(hello),
@@ -418,10 +399,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         )
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "session · sess")
+        self.assertEqual(session_thread_name(hello), "session")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `session · sess`: <#555>",
+            "Every Code session connected for `session`: <#555>",
         )
         self.assertIn("branch: `unknown`", session_start_message(hello))
 
@@ -430,18 +411,11 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
         hello.branch = "code/project-task"
         thread = SimpleNamespace(id=555)
 
-        self.assertEqual(session_thread_name(hello), "project · code/project-task · sess")
+        self.assertEqual(session_thread_name(hello), "project · code/project-task")
         self.assertEqual(
             session_notification_message(hello, thread),
-            "Every Code session connected for `project · code/project-task · sess`: <#555>",
+            "Every Code session connected for `project` on `code/project-task`: <#555>",
         )
-
-    def test_session_thread_text_uses_start_time_and_short_session_id(self) -> None:
-        hello = make_hello()
-        hello.session_id = "05ddf473-6cf3-4850-ac00-8f0a158d0c9d"
-        hello.session_epoch = "1710000000000"
-
-        self.assertRegex(session_thread_name(hello), r"^project · \d{2}:\d{2} 05dd$")
 
     def test_session_thread_text_omits_common_default_branch_names(self) -> None:
         thread = SimpleNamespace(id=555)
@@ -450,10 +424,10 @@ class ThreadFormattingTests(unittest.IsolatedAsyncioTestCase):
             hello = make_hello()
             hello.branch = branch
 
-            self.assertEqual(session_thread_name(hello), "project · sess")
+            self.assertEqual(session_thread_name(hello), "project")
             self.assertEqual(
                 session_notification_message(hello, thread),
-                "Every Code session connected for `project · sess`: <#555>",
+                "Every Code session connected for `project`: <#555>",
             )
 
     def test_session_thread_text_marks_every_code_origin(self) -> None:
@@ -1923,7 +1897,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             "\n".join(
                 [
                     "Live Every Code sessions:",
-                    "- `project · sess` (online, Mac Studio) <#555>",
+                    "- `project` (online, Mac Studio) <#555>",
                 ]
             ),
         )
@@ -1997,7 +1971,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
             bridge.session_status_summary(thread, SimpleNamespace(id=123)),
             "\n".join(
                 [
-                    "Every Code `project · sess`",
+                    "Every Code `project`",
                     "state: online",
                     "host: Mac Studio",
                     "status: Turn started",
@@ -2044,122 +2018,6 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
                 ]
             ),
         )
-
-    async def test_session_metadata_changed_renames_human_thread_to_working_branch(self) -> None:
-        config = Config()
-        thread = FakeThread(555)
-        bridge = EveryCodeBridge(FakeBot(config, thread))
-        session = EveryCodeSession(
-            hello=make_hello(),
-            websocket=FakeWebSocket(),
-            thread_id=555,
-        )
-        bridge.sessions.register(session)
-        bridge.sessions.bind_thread("session-1", 555)
-
-        await bridge.handle_session_metadata_changed(
-            SessionMetadataChanged(
-                session_id="session-1",
-                session_epoch="epoch-1",
-                cwd="/tmp/project-worktree",
-                branch="code/project-task",
-                reason="working_branch_selected",
-            )
-        )
-
-        self.assertEqual(session.hello.cwd, "/tmp/project")
-        self.assertEqual(session.hello.branch, "code/project-task")
-        self.assertEqual(thread.name, "project · code/project-task · sess")
-        self.assertEqual(thread.edits[-1]["reason"], "Every Code working branch selected")
-
-    async def test_session_metadata_changed_preserves_missing_branch(self) -> None:
-        config = Config()
-        thread = FakeThread(555)
-        bridge = EveryCodeBridge(FakeBot(config, thread))
-        session = EveryCodeSession(
-            hello=make_hello(),
-            websocket=FakeWebSocket(),
-            thread_id=555,
-        )
-        bridge.sessions.register(session)
-        bridge.sessions.bind_thread("session-1", 555)
-
-        await bridge.handle_session_metadata_changed(
-            SessionMetadataChanged(
-                session_id="session-1",
-                session_epoch="epoch-1",
-                cwd="/tmp/project-worktree",
-                branch=None,
-                reason="working_branch_selected",
-            )
-        )
-
-        self.assertEqual(session.hello.cwd, "/tmp/project")
-        self.assertEqual(session.hello.branch, "main")
-        self.assertIsNone(thread.name)
-        self.assertEqual(thread.edits, [])
-
-    async def test_session_metadata_changed_fetches_uncached_thread_before_renaming(self) -> None:
-        config = Config()
-        thread = FakeThread(555)
-        bot = FetchOnlyFakeBot(config, thread)
-        bridge = EveryCodeBridge(bot)
-        session = EveryCodeSession(
-            hello=make_hello(),
-            websocket=FakeWebSocket(),
-            thread_id=555,
-        )
-        bridge.sessions.register(session)
-        bridge.sessions.bind_thread("session-1", 555)
-
-        await bridge.handle_session_metadata_changed(
-            SessionMetadataChanged(
-                session_id="session-1",
-                session_epoch="epoch-1",
-                cwd="/tmp/project-worktree",
-                branch="code/project-task",
-                reason="working_branch_selected",
-            )
-        )
-
-        self.assertEqual(bot.fetch_channel_calls, [555])
-        self.assertEqual(thread.name, "project · code/project-task · sess")
-
-    async def test_session_metadata_changed_skips_every_code_origin_rename(self) -> None:
-        config = Config()
-        thread = FakeThread(555)
-        bridge = EveryCodeBridge(FakeBot(config, thread))
-        hello = SessionHello(
-            session_id="session-1",
-            session_epoch="epoch-1",
-            host_label="Mac Studio",
-            cwd="/tmp/project",
-            branch="main",
-            pid=42,
-            origin=SessionOrigin(
-                kind="every_code",
-                request_id="every-code-cbusillo-syo-67",
-                repository="cbusillo/sellyouroutboard",
-                issue_number=67,
-                issue_url="https://github.com/cbusillo/sellyouroutboard/issues/67",
-            ),
-        )
-        session = EveryCodeSession(hello=hello, websocket=FakeWebSocket(), thread_id=555)
-        bridge.sessions.register(session)
-        bridge.sessions.bind_thread("session-1", 555)
-
-        await bridge.handle_session_metadata_changed(
-            SessionMetadataChanged(
-                session_id="session-1",
-                session_epoch="epoch-1",
-                cwd="/tmp/project-worktree",
-                branch="code/project-task",
-                reason="working_branch_selected",
-            )
-        )
-
-        self.assertEqual(session.hello.branch, "code/project-task")
-        self.assertEqual(thread.edits, [])
 
     async def test_reconnect_reuses_matching_thread_with_assistant_history(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- remove the generated session discriminator from local Every Code thread titles
- remove the unused session metadata rename message and Discord rename handler
- keep default branch names hidden in thread titles

## Tests
- uv run ruff format --check discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/protocol.py tests/test_every_code.py
- uv run ruff check discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/protocol.py tests/test_every_code.py
- uv run mypy discord_blue/doodads/every_code/threads.py discord_blue/doodads/every_code/bridge.py discord_blue/doodads/every_code/protocol.py tests/test_every_code.py
- uv run python -m unittest tests.test_every_code -q

## Inspection
- PyCharm changed-files inspection reported weak warnings in existing Every Code/test code paths; no blocking errors from this cleanup.