### PR TITLE
Preserve active Every Code channel notifications

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -40,6 +40,7 @@ from discord_blue.doodads.every_code.threads import SessionThread
 from discord_blue.doodads.every_code.threads import auto_join_configured_users
 from discord_blue.doodads.every_code.threads import create_session_thread
 from discord_blue.doodads.every_code.threads import get_every_code_channel
+from discord_blue.doodads.every_code.threads import session_notification_message
 from discord_blue.doodads.every_code.threads import session_thread_name
 from discord_blue.doodads.every_code.threads import session_start_message
 from discord_blue.plugs.discord_plug import BlueBot
@@ -58,6 +59,7 @@ SESSION_NOTIFICATION_PREFIXES = (
     SESSION_NOTIFICATION_PREFIX,
     "Every Code automated session connected for ",
 )
+SESSION_NOTIFICATION_THREAD_RE = re.compile(r"<#(?P<thread_id>\d+)>")
 MARKDOWN_CODE_FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?P<info>[^`~\n]*)$")
 RESUME_SESSION_RE = re.compile(
     r"\bresume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b",
@@ -381,11 +383,14 @@ class EveryCodeBridge:
             return
 
         deleted = 0
+        active_thread_ids = set(self.sessions.by_thread)
         try:
             async for message in channel.history():
                 if message.author.id != bot_user.id:
                     continue
                 if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):
+                    continue
+                if self.notification_thread_id(message.content) in active_thread_ids:
                     continue
                 try:
                     await message.delete()
@@ -525,7 +530,47 @@ class EveryCodeBridge:
             except discord.DiscordException:
                 logger.warning("Unable to reopen Every Code thread %s", thread.id)
         await auto_join_configured_users(self.bot, thread)
-        return SessionThread(thread=thread, notification_message_id=None)
+        notification_message_id = await self.ensure_session_notification(hello, thread)
+        return SessionThread(thread=thread, notification_message_id=notification_message_id)
+
+    async def ensure_session_notification(self, hello: SessionHello, thread: discord.Thread) -> int | None:
+        existing_message_id = await self.find_session_notification_for_thread(thread.id)
+        if existing_message_id is not None:
+            return existing_message_id
+        try:
+            channel = await get_every_code_channel(self.bot)
+            message = await send_every_code_message(channel, session_notification_message(hello, thread))
+        except (discord.DiscordException, ValueError):
+            logger.warning("Unable to create Every Code notification for thread %s", thread.id)
+            return None
+        return message.id
+
+    async def find_session_notification_for_thread(self, thread_id: int) -> int | None:
+        try:
+            channel = await get_every_code_channel(self.bot)
+        except ValueError:
+            return None
+        bot_user = self.bot.user
+        if bot_user is None:
+            return None
+        try:
+            async for message in channel.history(limit=50):
+                if message.author.id != bot_user.id:
+                    continue
+                if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):
+                    continue
+                if self.notification_thread_id(message.content) == thread_id:
+                    return message.id
+        except discord.DiscordException:
+            logger.warning("Unable to scan Every Code notifications for thread %s", thread_id)
+        return None
+
+    @staticmethod
+    def notification_thread_id(content: str) -> int | None:
+        match = SESSION_NOTIFICATION_THREAD_RE.search(content)
+        if match is None:
+            return None
+        return int(match.group("thread_id"))
 
     async def find_existing_session_thread(self, hello: SessionHello) -> discord.Thread | None:
         try:

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -571,6 +571,34 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(unrelated_bot_notice.deleted)
         self.assertFalse(user_notice.deleted)
 
+    async def test_cleanup_stale_session_notifications_preserves_live_session_notice(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        live_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project`: <#555>",
+        )
+        stale_notice = add_bot_message(
+            channel,
+            102,
+            "Every Code session connected for `other`: <#556>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+
+        await bridge.cleanup_stale_session_notifications()
+
+        self.assertFalse(live_notice.deleted)
+        self.assertTrue(stale_notice.deleted)
+
     async def test_delete_session_notification_for_thread_deletes_matching_bot_notice(self) -> None:
         config = Config()
         config.every_code.channel_id = 321
@@ -2101,13 +2129,30 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         session_thread = await bridge.find_or_create_session_thread(hello)
 
         self.assertIs(session_thread.thread, original_thread)
-        self.assertIsNone(session_thread.notification_message_id)
+        self.assertEqual(session_thread.notification_message_id, 801)
+        self.assertEqual(channel.sent_messages, [session_notification_message(hello, original_thread)])
         self.assertFalse(original_thread.archived)
         self.assertFalse(original_thread.locked)
         self.assertEqual(
             original_thread.edits[0]["reason"],
             "Reattaching live Every Code session after bridge restart",
         )
+
+    async def test_reconnect_reuses_existing_parent_notification(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        hello = make_hello()
+        original_thread = FakeThread(555)
+        add_bot_message(original_thread, 1, session_start_message(hello))
+        channel = FakeTextChannel(321, [original_thread])
+        notice = add_bot_message(channel, 701, session_notification_message(hello, original_thread))
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+
+        session_thread = await bridge.find_or_create_session_thread(hello)
+
+        self.assertIs(session_thread.thread, original_thread)
+        self.assertEqual(session_thread.notification_message_id, notice.id)
+        self.assertEqual(channel.sent_messages, [])
 
     async def test_same_session_reconnect_reuses_current_thread(self) -> None:
         config = Config()
@@ -2136,6 +2181,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertIs(session_thread.thread, original_thread)
+        self.assertEqual(session_thread.notification_message_id, 801)
         self.assertIsNone(bridge.sessions.remove_if_current(old_session))
         self.assertIs(bridge.sessions.get(hello.session_id), new_session)
 


### PR DESCRIPTION
## Summary
- preserve parent-channel Every Code notifications for live sessions during startup cleanup
- create or reuse a parent-channel notification when a live session reattaches to an existing thread
- add regression tests for live-session notification preservation and reattach notification behavior

## Regression Fixed
After PR #73 deployed, startup cleanup deleted all parent-channel session notifications, leaving `#every-code` blank even though live session threads still existed. Parent-channel notifications are the visible session index, so cleanup must keep notifications linked to active sessions.

## Validation
- `uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run mypy discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run python -m unittest tests.test_every_code -q`
- `uv run python -m unittest discover -s tests -q`

JetBrains closeout routed to PyCharm and cleaned up, but returned stale cached results instead of a fresh inspection for this hotfix branch.
