### PR TITLE
Scan full Every Code notification history

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -554,7 +554,7 @@ class EveryCodeBridge:
         if bot_user is None:
             return None
         try:
-            async for message in channel.history(limit=50):
+            async for message in channel.history(limit=None):
                 if message.author.id != bot_user.id:
                     continue
                 if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):
@@ -1846,7 +1846,7 @@ class EveryCodeBridge:
 
         mention = f"<#{thread_id}>"
         try:
-            async for message in channel.history(limit=50):
+            async for message in channel.history(limit=None):
                 if message.author.id != bot_user.id:
                     continue
                 if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -627,6 +627,38 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(other_notice.deleted)
         self.assertFalse(user_notice.deleted)
 
+    async def test_delete_session_notification_for_thread_scans_full_history(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        matching_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project`: <#555>",
+        )
+        for index in range(60):
+            add_bot_message(channel, 200 + index, f"Every Code status summary {index}")
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+
+        await bridge.delete_session_notification_for_thread(555)
+
+        self.assertTrue(matching_notice.deleted)
+
+    async def test_find_session_notification_for_thread_scans_full_history(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        matching_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project`: <#555>",
+        )
+        for index in range(60):
+            add_bot_message(channel, 200 + index, f"Every Code status summary {index}")
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+
+        self.assertEqual(await bridge.find_session_notification_for_thread(555), matching_notice.id)
+
     async def test_close_session_thread_deletes_reused_thread_notification(self) -> None:
         config = Config()
         config.every_code.channel_id = 321


### PR DESCRIPTION
## Summary
- scan the full parent-channel history when finding or deleting Every Code notifications for a reused thread
- add regression coverage with the matching notification buried beyond the previous scan window

## Review Finding
Follow-up for auto-review feedback after #74: the targeted notification cleanup/reuse helpers used a bounded history scan, so older active-channel notification rows could be missed.

## Validation
- `uv run python -m unittest tests.test_every_code.BridgeTests.test_delete_session_notification_for_thread_scans_full_history tests.test_every_code.BridgeTests.test_find_session_notification_for_thread_scans_full_history -q`
- `uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run mypy discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run python -m unittest tests.test_every_code -q`
- `uv run python -m unittest discover -s tests -q`

JetBrains inspection closeout completed with fresh weak warnings in `tests/test_every_code.py` that predate this change; no errors were reported.
