### PR TITLE
Recheck live sessions during Every Code notification cleanup

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -383,14 +383,14 @@ class EveryCodeBridge:
             return
 
         deleted = 0
-        active_thread_ids = set(self.sessions.by_thread)
         try:
             async for message in channel.history():
                 if message.author.id != bot_user.id:
                     continue
                 if not message.content.startswith(SESSION_NOTIFICATION_PREFIXES):
                     continue
-                if self.notification_thread_id(message.content) in active_thread_ids:
+                thread_id = self.notification_thread_id(message.content)
+                if thread_id is not None and self.sessions.get_by_thread(thread_id) is not None:
                     continue
                 try:
                     await message.delete()

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -11,6 +11,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import patch
 
 from tests.fakes_every_code import FakeBot
 from tests.fakes_every_code import FakeInteraction
@@ -598,6 +599,34 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(live_notice.deleted)
         self.assertTrue(stale_notice.deleted)
+
+    async def test_cleanup_stale_session_notifications_rechecks_live_session_notice(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        live_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project`: <#555>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+        )
+        bridge.sessions.register(session)
+        original_notification_thread_id = EveryCodeBridge.notification_thread_id
+
+        def bind_during_cleanup(content: str) -> int | None:
+            thread_id = original_notification_thread_id(content)
+            if thread_id == 555 and bridge.sessions.get_by_thread(555) is None:
+                bridge.sessions.bind_thread("session-1", 555)
+            return thread_id
+
+        with patch.object(EveryCodeBridge, "notification_thread_id", side_effect=bind_during_cleanup):
+            await bridge.cleanup_stale_session_notifications()
+
+        self.assertFalse(live_notice.deleted)
 
     async def test_delete_session_notification_for_thread_deletes_matching_bot_notice(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- recheck the live session registry for each parent-channel notification before deleting it
- add regression coverage for reconnect binding that occurs while cleanup is scanning notifications

## Review Finding
Follow-up for auto-review feedback after #75: cleanup used a snapshot of active thread IDs, so a session that bound while cleanup was already scanning could still lose its parent-channel notification.

## Validation
- `uv run python -m unittest tests.test_every_code.BridgeTests.test_cleanup_stale_session_notifications_rechecks_live_session_notice -q`
- `uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run mypy discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run python -m unittest tests.test_every_code -q`
- `uv run python -m unittest discover -s tests -q`

JetBrains inspection closeout completed with fresh weak warnings in `tests/test_every_code.py`; no production-code inspection findings were reported.
