### PR TITLE
Serialize Every Code attach cleanup

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -271,6 +271,7 @@ class EveryCodeBridge:
         self._site: web.TCPSite | None = None
         self._cleanup_task: asyncio.Task[None] | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
+        self._session_attach_lock = asyncio.Lock()
 
     async def start(self) -> None:
         if self._runner is not None:
@@ -372,6 +373,10 @@ class EveryCodeBridge:
             await self.close_session_thread(removed)
 
     async def cleanup_stale_session_notifications(self) -> None:
+        async with self._session_attach_lock:
+            await self.cleanup_stale_session_notifications_locked()
+
+    async def cleanup_stale_session_notifications_locked(self) -> None:
         try:
             channel = await get_every_code_channel(self.bot)
         except ValueError:
@@ -468,18 +473,19 @@ class EveryCodeBridge:
             message_type = payload.get("type")
             if message_type == "hello":
                 hello = SessionHello.from_payload(payload)
-                session = EveryCodeSession(hello=hello, websocket=websocket)
-                self.sessions.register(session)
-                session_thread = await self.find_or_create_session_thread(hello)
-                self.sessions.bind_thread(
-                    hello.session_id,
-                    session_thread.thread.id,
-                    session_thread.notification_message_id,
-                )
-                await self.backfill_latest_assistant_message(
-                    session_thread.thread,
-                    hello,
-                )
+                async with self._session_attach_lock:
+                    session = EveryCodeSession(hello=hello, websocket=websocket)
+                    self.sessions.register(session)
+                    session_thread = await self.find_or_create_session_thread(hello)
+                    self.sessions.bind_thread(
+                        hello.session_id,
+                        session_thread.thread.id,
+                        session_thread.notification_message_id,
+                    )
+                    await self.backfill_latest_assistant_message(
+                        session_thread.thread,
+                        hello,
+                    )
                 await websocket.send_json({"type": "hello_ack", "thread_id": session_thread.thread.id})
             elif message_type == "heartbeat" and session is not None:
                 session.touch()

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -628,6 +628,34 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(live_notice.deleted)
 
+    async def test_cleanup_stale_session_notifications_waits_for_session_attach(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        channel = FakeTextChannel(321, [])
+        live_notice = add_bot_message(
+            channel,
+            101,
+            "Every Code session connected for `project`: <#555>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, channel=channel))
+        session_attach_lock = cast(Any, bridge)._session_attach_lock
+        await session_attach_lock.acquire()
+        cleanup_task = asyncio.create_task(bridge.cleanup_stale_session_notifications())
+        await asyncio.sleep(0)
+        self.assertFalse(cleanup_task.done())
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(),
+            thread_id=555,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555)
+        session_attach_lock.release()
+
+        await cleanup_task
+
+        self.assertFalse(live_notice.deleted)
+
     async def test_delete_session_notification_for_thread_deletes_matching_bot_notice(self) -> None:
         config = Config()
         config.every_code.channel_id = 321


### PR DESCRIPTION
## Summary
- serialize Every Code session attach/bind work with startup notification cleanup
- keep cleanup from deleting notices while a session is registered but not yet bound to its thread
- add regression coverage proving cleanup waits for attach/bind to finish before deleting notices

## Review Finding
Follow-up for delayed auto-review feedback after #76: cleanup could still race with a reconnect while the session was registered but not yet bound to a thread, causing a live parent-channel notice to be deleted.

## Validation
- `uv run python -m unittest tests.test_every_code.BridgeTests.test_cleanup_stale_session_notifications_waits_for_session_attach tests.test_every_code.BridgeTests.test_cleanup_stale_session_notifications_rechecks_live_session_notice -q`
- `uv run ruff format --check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run mypy discord_blue/doodads/every_code/bridge.py tests/test_every_code.py`
- `uv run python -m unittest tests.test_every_code -q`
- `uv run python -m unittest discover -s tests -q`

JetBrains inspection closeout completed with fresh weak warnings in `tests/test_every_code.py`; local warnings introduced by this PR were cleaned up, and no production-code inspection findings were reported.
