### PR TITLE
Close Every Code threads during bridge shutdown

### DIFF
--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -54,6 +54,7 @@ DISCORD_CODE_FENCE_WRAP_RESERVE = 80
 STARTUP_RECONNECT_GRACE_SECONDS = 20
 SHUTDOWN_WEBSOCKET_CLOSE_TIMEOUT_SECONDS = 2
 SHUTDOWN_RUNNER_CLEANUP_TIMEOUT_SECONDS = 5
+SHUTDOWN_THREAD_CLEANUP_TIMEOUT_SECONDS = 5
 AGENT_SESSION_CONNECT_PATH = "/agent-session/connect"
 EVERY_CODE_CONNECT_PATH = "/every-code/connect"
 SESSION_START_PREFIX = "Every Code session connected"
@@ -275,10 +276,12 @@ class EveryCodeBridge:
         self._cleanup_task: asyncio.Task[None] | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._session_attach_lock = asyncio.Lock()
+        self._stopping = False
 
     async def start(self) -> None:
         if self._runner is not None:
             return
+        self._stopping = False
 
         app = web.Application()
         self.register_routes(app)
@@ -326,6 +329,7 @@ class EveryCodeBridge:
     async def stop(self) -> None:
         if self._runner is None:
             return
+        self._stopping = True
         if self._cleanup_task is not None:
             self._cleanup_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -360,7 +364,13 @@ class EveryCodeBridge:
     async def disconnect_active_session(self, session_id: str, session: EveryCodeSession) -> None:
         if not session.websocket.closed:
             await self.close_session_websocket(session_id, session)
-        await self.close_session_thread(session)
+        try:
+            await asyncio.wait_for(
+                self.close_session_thread(session),
+                timeout=SHUTDOWN_THREAD_CLEANUP_TIMEOUT_SECONDS,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning("Every Code thread cleanup for %s timed out during shutdown", session_id)
 
     @staticmethod
     async def close_session_websocket(session_id: str, session: EveryCodeSession) -> None:
@@ -544,20 +554,29 @@ class EveryCodeBridge:
             message_type = payload.get("type")
             if message_type == "hello":
                 hello = SessionHello.from_payload(payload)
+                rejecting_stopping_session = False
+                session_thread: SessionThread | None = None
                 async with self._session_attach_lock:
-                    session = EveryCodeSession(hello=hello, websocket=websocket)
-                    self.sessions.register(session)
-                    session_thread = await self.find_or_create_session_thread(hello)
-                    self.sessions.bind_thread(
-                        hello.session_id,
-                        session_thread.thread.id,
-                        session_thread.notification_message_id,
-                    )
-                    await self.backfill_latest_assistant_message(
-                        session_thread.thread,
-                        hello,
-                    )
-                await websocket.send_json({"type": "hello_ack", "thread_id": session_thread.thread.id})
+                    if self._stopping:
+                        rejecting_stopping_session = True
+                    else:
+                        session = EveryCodeSession(hello=hello, websocket=websocket)
+                        self.sessions.register(session)
+                        session_thread = await self.find_or_create_session_thread(hello)
+                        self.sessions.bind_thread(
+                            hello.session_id,
+                            session_thread.thread.id,
+                            session_thread.notification_message_id,
+                        )
+                        await self.backfill_latest_assistant_message(
+                            session_thread.thread,
+                            hello,
+                        )
+                if rejecting_stopping_session:
+                    await websocket.close(message=b"bridge shutdown", drain=False)
+                    break
+                if session_thread is not None:
+                    await websocket.send_json({"type": "hello_ack", "thread_id": session_thread.thread.id})
             elif message_type == "heartbeat" and session is not None:
                 session.touch()
             elif message_type == "user_message":

--- a/discord_blue/doodads/every_code/bridge.py
+++ b/discord_blue/doodads/every_code/bridge.py
@@ -346,15 +346,21 @@ class EveryCodeBridge:
             self._site = None
 
     async def disconnect_active_sessions(self) -> None:
-        close_tasks: list[asyncio.Task[None]] = []
-        for session_id in list(self.sessions.by_session):
-            session = self.sessions.remove(session_id)
-            if session is None or session.websocket.closed:
-                continue
-            close_tasks.append(asyncio.create_task(self.close_session_websocket(session_id, session)))
+        async with self._session_attach_lock:
+            close_tasks: list[asyncio.Task[None]] = []
+            for session_id in list(self.sessions.by_session):
+                session = self.sessions.remove(session_id)
+                if session is None:
+                    continue
+                close_tasks.append(asyncio.create_task(self.disconnect_active_session(session_id, session)))
 
-        if close_tasks:
-            await asyncio.gather(*close_tasks)
+            if close_tasks:
+                await asyncio.gather(*close_tasks)
+
+    async def disconnect_active_session(self, session_id: str, session: EveryCodeSession) -> None:
+        if not session.websocket.closed:
+            await self.close_session_websocket(session_id, session)
+        await self.close_session_thread(session)
 
     @staticmethod
     async def close_session_websocket(session_id: str, session: EveryCodeSession) -> None:

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -197,6 +197,15 @@ class FakeTextChannel:
         message.deleted = True
         self._history = [stored for stored in self._history if stored.id != message_id]
 
+    async def fetch_message(self, message_id: int) -> FakeReplyMessage:
+        message = self._messages.get(message_id)
+        if message is None:
+            raise discord.NotFound(
+                response=SimpleNamespace(status=404, reason="Not Found"),
+                message=f"Message {message_id} not found",
+            )
+        return message
+
     async def history(
         self,
         limit: int | None = None,

--- a/tests/fakes_every_code.py
+++ b/tests/fakes_every_code.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import Protocol, TYPE_CHECKING
 
 import discord
 
@@ -10,6 +10,10 @@ from discord_blue.doodads.every_code.protocol import SessionHello
 
 if TYPE_CHECKING:
     from discord_blue.config import Config
+
+
+class UserLike(Protocol):
+    id: int
 
 
 class FakeWebSocket:
@@ -85,6 +89,7 @@ class FakeThread:
         archived: bool = False,
         locked: bool = False,
         manage_messages: bool = True,
+        members: list[int] | None = None,
     ) -> None:
         self.id = thread_id
         self.archived = archived
@@ -101,6 +106,8 @@ class FakeThread:
         self.edits: list[dict[str, object]] = []
         self.name: str | None = None
         self.left = False
+        self._member_ids = list(members or [])
+        self.removed_user_ids: list[int] = []
 
     def add_message(self, message: FakeReplyMessage) -> None:
         self._messages[message.id] = message
@@ -165,9 +172,13 @@ class FakeThread:
             self.name = name if isinstance(name, str) else None
         self.edits.append(kwargs)
 
-    @staticmethod
-    async def fetch_members() -> list[object]:
-        return []
+    async def fetch_members(self) -> list[object]:
+        return [SimpleNamespace(id=member_id) for member_id in self._member_ids]
+
+    async def remove_user(self, user: UserLike) -> None:
+        user_id = user.id
+        self.removed_user_ids.append(user_id)
+        self._member_ids = [member_id for member_id in self._member_ids if member_id != user_id]
 
     async def leave(self) -> None:
         self.left = True

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -839,7 +839,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
     async def test_stop_disconnects_sessions_before_runner_cleanup(self) -> None:
         config = Config()
         config.every_code.channel_id = 321
-        thread = FakeThread(555)
+        thread = FakeThread(555, members=[111, 222, 999])
         channel = FakeTextChannel(321, [thread])
         notification = add_bot_message(
             channel,
@@ -879,6 +879,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(thread.archived)
         self.assertTrue(thread.locked)
         self.assertTrue(thread.left)
+        self.assertEqual(thread.removed_user_ids, [111, 222])
         self.assertIsNone(bridge.sessions.get("session-1"))
         self.assertIsNone(bridge.sessions.get_by_thread(555))
         self.assertIsNone(bridge._runner)
@@ -886,7 +887,7 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
     async def test_stop_closes_thread_for_already_closed_websocket(self) -> None:
         config = Config()
         config.every_code.channel_id = 321
-        thread = FakeThread(555)
+        thread = FakeThread(555, members=[111, 999])
         channel = FakeTextChannel(321, [thread])
         notification = add_bot_message(
             channel,
@@ -917,13 +918,14 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(thread.archived)
         self.assertTrue(thread.locked)
         self.assertTrue(thread.left)
+        self.assertEqual(thread.removed_user_ids, [111])
         self.assertIsNone(bridge.sessions.get("session-1"))
         self.assertIsNone(bridge.sessions.get_by_thread(555))
 
     async def test_disconnect_active_sessions_waits_for_session_attach(self) -> None:
         config = Config()
         config.every_code.channel_id = 321
-        thread = FakeThread(555)
+        thread = FakeThread(555, members=[111, 999])
         channel = FakeTextChannel(321, [thread])
         notification = add_bot_message(
             channel,
@@ -950,8 +952,33 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(thread.archived)
         self.assertTrue(thread.locked)
         self.assertTrue(thread.left)
+        self.assertEqual(thread.removed_user_ids, [111])
         self.assertIsNone(bridge.sessions.get("session-1"))
         self.assertIsNone(bridge.sessions.get_by_thread(555))
+
+    async def test_disconnect_active_session_bounds_thread_cleanup(self) -> None:
+        config = Config()
+        bridge = EveryCodeBridge(FakeBot(config))
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=FakeWebSocket(closed=True),
+            thread_id=555,
+        )
+
+        async def slow_close_thread(_session: object) -> None:
+            await asyncio.sleep(60)
+
+        bridge.close_session_thread = slow_close_thread  # type: ignore[method-assign]
+        bridge_module_any = cast(Any, bridge_module)
+        original_timeout = bridge_module_any.SHUTDOWN_THREAD_CLEANUP_TIMEOUT_SECONDS
+        bridge_module_any.SHUTDOWN_THREAD_CLEANUP_TIMEOUT_SECONDS = 0.01
+        try:
+            with self.assertLogs(bridge_module.logger, level="WARNING") as logs:
+                await bridge.disconnect_active_session("session-1", session)
+        finally:
+            bridge_module_any.SHUTDOWN_THREAD_CLEANUP_TIMEOUT_SECONDS = original_timeout
+
+        self.assertIn("Every Code thread cleanup for session-1 timed out during shutdown", "\n".join(logs.output))
 
     async def test_stop_disconnects_sessions_concurrently(self) -> None:
         config = Config()

--- a/tests/test_every_code.py
+++ b/tests/test_every_code.py
@@ -838,7 +838,15 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_stop_disconnects_sessions_before_runner_cleanup(self) -> None:
         config = Config()
-        bridge = EveryCodeBridge(FakeBot(config))
+        config.every_code.channel_id = 321
+        thread = FakeThread(555)
+        channel = FakeTextChannel(321, [thread])
+        notification = add_bot_message(
+            channel,
+            777,
+            "Every Code session connected for `project`: <#555>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, thread=thread, channel=channel))
         websocket = FakeWebSocket()
         session = EveryCodeSession(
             hello=make_hello(),
@@ -867,9 +875,83 @@ class BridgeTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(runner.cleaned)
         self.assertTrue(websocket.closed)
         self.assertEqual(websocket.close_messages, [b"bridge shutdown"])
+        self.assertTrue(notification.deleted)
+        self.assertTrue(thread.archived)
+        self.assertTrue(thread.locked)
+        self.assertTrue(thread.left)
         self.assertIsNone(bridge.sessions.get("session-1"))
         self.assertIsNone(bridge.sessions.get_by_thread(555))
         self.assertIsNone(bridge._runner)
+
+    async def test_stop_closes_thread_for_already_closed_websocket(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        thread = FakeThread(555)
+        channel = FakeTextChannel(321, [thread])
+        notification = add_bot_message(
+            channel,
+            777,
+            "Every Code session connected for `project`: <#555>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, thread=thread, channel=channel))
+        websocket = FakeWebSocket(closed=True)
+        session = EveryCodeSession(
+            hello=make_hello(),
+            websocket=websocket,
+            thread_id=555,
+            notification_message_id=777,
+        )
+        bridge.sessions.register(session)
+        bridge.sessions.bind_thread("session-1", 555, notification_message_id=777)
+
+        class FakeRunner:
+            async def cleanup(self) -> None:
+                pass
+
+        bridge._runner = FakeRunner()
+
+        await bridge.stop()
+
+        self.assertEqual(websocket.close_messages, [])
+        self.assertTrue(notification.deleted)
+        self.assertTrue(thread.archived)
+        self.assertTrue(thread.locked)
+        self.assertTrue(thread.left)
+        self.assertIsNone(bridge.sessions.get("session-1"))
+        self.assertIsNone(bridge.sessions.get_by_thread(555))
+
+    async def test_disconnect_active_sessions_waits_for_session_attach(self) -> None:
+        config = Config()
+        config.every_code.channel_id = 321
+        thread = FakeThread(555)
+        channel = FakeTextChannel(321, [thread])
+        notification = add_bot_message(
+            channel,
+            777,
+            "Every Code session connected for `project`: <#555>",
+        )
+        bridge = EveryCodeBridge(FakeBot(config, thread=thread, channel=channel))
+        websocket = FakeWebSocket()
+        session = EveryCodeSession(hello=make_hello(), websocket=websocket)
+        bridge.sessions.register(session)
+        session_attach_lock = bridge._session_attach_lock
+        await session_attach_lock.acquire()
+        disconnect_task = asyncio.create_task(bridge.disconnect_active_sessions())
+        await asyncio.sleep(0)
+        self.assertFalse(disconnect_task.done())
+
+        bridge.sessions.bind_thread("session-1", 555, notification_message_id=777)
+        session_attach_lock.release()
+
+        await disconnect_task
+
+        self.assertEqual(websocket.close_messages, [b"bridge shutdown"])
+        self.assertTrue(notification.deleted)
+        self.assertTrue(thread.archived)
+        self.assertTrue(thread.locked)
+        self.assertTrue(thread.left)
+        self.assertIsNone(bridge.sessions.get("session-1"))
+        self.assertIsNone(bridge.sessions.get_by_thread(555))
 
     async def test_stop_disconnects_sessions_concurrently(self) -> None:
         config = Config()


### PR DESCRIPTION
## Summary
- close active Every Code Discord threads during bridge shutdown instead of only closing websockets
- protect shutdown cleanup with the existing session attach lock so partially-attached sessions cannot leave orphaned threads
- add regression coverage for bound sessions, already-closed websockets, and attach-time shutdown races

## Validation
- uv run python -m unittest discover -s tests -q
- uv run ruff check --diff discord_blue/doodads/every_code/bridge.py tests/test_every_code.py tests/fakes_every_code.py
- uv run ruff check discord_blue/doodads/every_code/bridge.py tests/test_every_code.py tests/fakes_every_code.py
- uv run mypy .