### PR TITLE
Document CodeQL merge protection

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -33,11 +33,7 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": [
-        "changed_files",
-        "directory",
-        "whole_project"
-      ]
+      "scopePreference": ["changed_files", "directory", "whole_project"]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -56,11 +52,15 @@
     "Dependency Graph",
     "Dependabot Updates"
   ],
-  "requiredStatusChecks": [
-    "validate",
-    "Analyze (actions)",
-    "Analyze (python)"
-  ],
+  "requiredStatusChecks": ["validate"],
+  "codeScanningMergeProtection": {
+    "ruleset": "Require code scanning results",
+    "target": "defaultBranch",
+    "tool": "CodeQL",
+    "alertsThreshold": "errors",
+    "securityAlertsThreshold": "high_or_higher",
+    "dependabotDefaultSetupException": true
+  },
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],


### PR DESCRIPTION
## Summary
- record `validate` as the only required status check
- document the dedicated CodeQL merge-protection ruleset and thresholds
- note GitHub's documented default-setup exception for Dependabot PRs

## GitHub settings applied
- created the active `Require code scanning results` ruleset for the default branch
- require CodeQL errors and high-or-higher security alerts to block merges
- removed `Analyze (actions)` and `Analyze (python)` from legacy required status checks
- confirmed Dependabot PR #100 changed from blocked to mergeable

## Validation
- `jq empty .github/github.json`
- `prettier --check .github/github.json`
- `git diff --check`

Official guidance: https://docs.github.com/en/code-security/concepts/code-scanning/merge-protection
