### PR TITLE
Remove redundant CodeQL target metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -55,7 +55,6 @@
   "requiredStatusChecks": ["validate"],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
-    "target": "defaultBranch",
     "tool": "CodeQL",
     "alertsThreshold": "errors",
     "securityAlertsThreshold": "high_or_higher",


### PR DESCRIPTION
## Summary
- remove the redundant CodeQL merge-protection `target` metadata
- rely on the repository's existing top-level default branch and live ruleset scope
- avoid classifying repository workflow metadata as runtime provider authority

## Validation
- `jq empty .github/github.json`
- `prettier --check .github/github.json`
- `git diff --check`
