### PR TITLE
Require validation and image build success

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -52,7 +52,7 @@
     "Dependency Graph",
     "Dependabot Updates"
   ],
-  "requiredStatusChecks": ["validate"],
+  "requiredStatusChecks": ["ci-gate"],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
     "tool": "CodeQL",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,30 @@ jobs:
           fi
         shell: bash
 
+  ci_gate:
+    name: ci-gate
+    if: ${{ always() }}
+    needs:
+      - validate
+      - image
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Confirm validation and image jobs passed
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          IMAGE_RESULT: ${{ needs.image.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "$VALIDATE_RESULT" != "success" ] || [ "$IMAGE_RESULT" != "success" ]; then
+            echo "validate=$VALIDATE_RESULT" >&2
+            echo "image=$IMAGE_RESULT" >&2
+            exit 1
+          fi
+
+          echo "Validation and image checks passed."
+
   launchplane-deploy:
     needs: image
     if: >-

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ validates the repo, publishes an immutable GHCR image, and asks Launchplane to
 deploy that image to the registered Dokploy application on the Discord Blue LXC.
 
 - CI proves the Docker image builds for every PR and push.
+- The required `ci-gate` context fails closed unless both application
+  validation and the container image build succeed.
 - The production LXC keeps `/var/lib/discord-blue` as the durable state mount.
 - Dokploy pulls a versioned image and replaces the container.
 - Launchplane owns the deploy record, Dokploy mutation, and rollback decision.

--- a/tests/test_repo_workflow_contracts.py
+++ b/tests/test_repo_workflow_contracts.py
@@ -1,0 +1,23 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class RepoWorkflowContractTests(unittest.TestCase):
+    def test_ci_gate_requires_validation_and_image_build(self) -> None:
+        metadata = json.loads((REPO_ROOT / ".github/github.json").read_text(encoding="utf-8"))
+        workflow = (REPO_ROOT / ".github/workflows/main.yml").read_text(encoding="utf-8")
+
+        self.assertEqual(["ci-gate"], metadata["requiredStatusChecks"])
+        self.assertIn("name: ci-gate", workflow)
+        self.assertIn("if: ${{ always() }}", workflow)
+        self.assertIn("VALIDATE_RESULT: ${{ needs.validate.result }}", workflow)
+        self.assertIn("IMAGE_RESULT: ${{ needs.image.result }}", workflow)
+        self.assertIn('if [ "$VALIDATE_RESULT" != "success" ]', workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fan application validation and the container image build into `ci-gate`
- emit the stable aggregate context on every pull request and fail closed
- record and test the required context

## Validation
- `actionlint -config-file .github/actionlint.yaml .github/workflows/main.yml`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run python -m unittest discover -s tests -q`
- PyCharm changed-files inspection: GREEN

Closes cbusillo/launchplane#1645